### PR TITLE
fix: change blog loading from eager: false to eager: true for Vercel …

### DIFF
--- a/src/hooks/useBlog.ts
+++ b/src/hooks/useBlog.ts
@@ -63,24 +63,21 @@ function parseFrontmatter(content: string): { meta: Record<string, unknown>; con
 
 async function loadBlogPosts(language: BlogLanguage): Promise<BlogPost[]> {
   try {
-    // Simulamos el delay para mostrar el loading state
     await new Promise((resolve) => setTimeout(resolve, 100))
 
     const posts: BlogPost[] = []
 
-    // Usamos import.meta.glob para cargar los archivos markdown
     const modules = import.meta.glob('/src/content/blog/**/*.md', {
       query: '?raw',
       import: 'default',
-      eager: false,
+      eager: true,
     })
 
-    for (const [filePath, moduleLoader] of Object.entries(modules)) {
-      // Verificamos si el archivo corresponde al idioma actual
+    for (const [filePath, module] of Object.entries(modules)) {
       if (!filePath.includes(`/blog/${language}/`)) continue
 
       try {
-        const content = await moduleLoader()
+        const content = module
 
         if (typeof content !== 'string') {
           console.warn(`Expected string content from ${filePath}, got ${typeof content}`)
@@ -116,7 +113,6 @@ async function loadBlogPosts(language: BlogLanguage): Promise<BlogPost[]> {
       }
     }
 
-    // Ordenamos por fecha (más recientes primero)
     posts.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
 
     return posts


### PR DESCRIPTION
This pull request updates the blog post loading logic in `src/hooks/useBlog.ts` to improve performance and simplify how markdown files are imported and processed.

Performance and code simplification:

* Changed the `import.meta.glob` call to use `eager: true`, allowing markdown files to be loaded synchronously and eliminating the need for dynamic loading and awaiting each file.
* Refactored the loop to use the loaded module directly, simplifying the code and removing unnecessary asynchronous operations.

Code cleanup:

* Removed outdated comments related to simulated delay, markdown file loading, and sorting, making the code cleaner and easier to read. [[1]](diffhunk://#diff-098ae6a6300e99bedc4265c9f80313e5c0c940019649cc7665385787a9835d2cL66-R80) [[2]](diffhunk://#diff-098ae6a6300e99bedc4265c9f80313e5c0c940019649cc7665385787a9835d2cL119)…deployment

- Change import.meta.glob to use eager: true to ensure markdown files are loaded at build time
- Remove async moduleLoader() call and use direct module access
- This fixes the issue where blog posts were not showing in Vercel production builds
- Markdown files are now bundled directly instead of being loaded dynamically at runtime