### PR TITLE
fix: vercel deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
   "installCommand": "pnpm install",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
This pull request updates the Vercel configuration to use the recommended `routes` property instead of the deprecated `rewrites` property for handling routing logic.

Routing configuration update:
* Replaced the `rewrites` array with a `routes` array in `vercel.json`, using the new format for filesystem handling and fallback to `index.html`.