### PR TITLE
feat: allow inclusion of blog content markdown in the build

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -9,6 +9,8 @@ src/test/**
 docs/
 *.md
 !README.md
+# Allow blog content markdown to be included in the build
+!src/content/blog/**/*.md
 
 # Development files
 .env.local


### PR DESCRIPTION
This pull request updates the `.vercelignore` file to ensure that blog content markdown files are included in the build, while still excluding other markdown files except for `README.md`.

Build configuration:

* Updated `.vercelignore` to allow all markdown files under `src/content/blog/` to be included in the build, ensuring blog content is not ignored.