### PR TITLE
feat: Migrate from Vercel Analytics to Umami self-hosted analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ VITE_FORMSPREE_ID=your_formspree_id_here
 # Google reCAPTCHA v3 Configuration
 VITE_RECAPTCHA_SITE_KEY=your_recaptcha_site_key_here
 VITE_LINKEDIN_USERNAME=your_linkedin_username_here
+
+# Umami Analytics Configuration
+VITE_UMAMI_WEBSITE_ID=your_umami_website_id_here

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio - Miguel Ángel de Dios</title>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+    <!-- Umami Analytics -->
+    <script defer src="https://mywebsite-umami.mddiosc.cloud/script.js" data-website-id="%VITE_UMAMI_WEBSITE_ID%"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
-    "@vercel/analytics": "^1.6.1",
-    "@vercel/speed-insights": "^1.3.1",
     "axios": "^1.13.2",
     "dompurify": "^3.3.1",
     "framer-motion": "^12.23.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,6 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.91.1
         version: 5.91.1(@tanstack/react-query@5.90.12(react@19.2.3))(react@19.2.3)
-      '@vercel/analytics':
-        specifier: ^1.6.1
-        version: 1.6.1(react@19.2.3)
-      '@vercel/speed-insights':
-        specifier: ^1.3.1
-        version: 1.3.1(react@19.2.3)
       axios:
         specifier: ^1.13.2
         version: 1.13.2
@@ -1146,55 +1140,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-
-  '@vercel/speed-insights@1.3.1':
-    resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
-    peerDependencies:
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
 
   '@vitejs/plugin-react-swc@3.11.0':
     resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
@@ -4546,14 +4491,6 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@vercel/analytics@1.6.1(react@19.2.3)':
-    optionalDependencies:
-      react: 19.2.3
-
-  '@vercel/speed-insights@1.3.1(react@19.2.3)':
-    optionalDependencies:
-      react: 19.2.3
 
   '@vitejs/plugin-react-swc@3.11.0(@swc/helpers@0.5.17)(vite@7.3.0(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
     dependencies:

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 import { Outlet } from 'react-router'
 
-import { Analytics } from '@vercel/analytics/react'
 import { motion } from 'framer-motion'
 
 import { useHtmlLang } from '../hooks/useHtmlLang'
@@ -62,7 +61,6 @@ const Layout = () => {
         />
       </main>
       <Footer />
-      <Analytics />
     </div>
   )
 }

--- a/src/hooks/useSecurity.ts
+++ b/src/hooks/useSecurity.ts
@@ -60,11 +60,11 @@ export const useSecurity = () => {
     return {
       'Content-Security-Policy':
         "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline' https://vercel.live; " +
+        "script-src 'self' 'unsafe-inline' https://mywebsite-umami.mddiosc.cloud; " +
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "font-src 'self' https://fonts.gstatic.com; " +
         "img-src 'self' data: https:; " +
-        "connect-src 'self' https://vercel.live;",
+        "connect-src 'self' https://mywebsite-umami.mddiosc.cloud;",
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'X-XSS-Protection': '1; mode=block',

--- a/src/lib/resourcePreloading.ts
+++ b/src/lib/resourcePreloading.ts
@@ -41,8 +41,8 @@ export function preconnectToOrigins() {
   preconnect('https://www.google.com')
   preconnect('https://www.gstatic.com')
 
-  // Vercel Analytics
-  preconnect('https://vitals.vercel-insights.com')
+  // Umami Analytics
+  preconnect('https://mywebsite-umami.mddiosc.cloud')
 }
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { SpeedInsights } from '@vercel/speed-insights/react'
 import { createRoot } from 'react-dom/client'
 
 import App from './App'
@@ -30,7 +29,6 @@ if (root) {
           <App />
         )}
         <ReactQueryDevtools initialIsOpen={false} />
-        <SpeedInsights />
       </QueryClientProvider>
     </StrictMode>,
   )

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live https://va.vercel-scripts.com https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://vercel.live https://va.vercel-scripts.com https://api.github.com https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://mywebsite-umami.mddiosc.cloud https://api.github.com https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';"
         },
         {
           "key": "X-Content-Type-Options",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,19 @@ import react from '@vitejs/plugin-react-swc'
 import { defineConfig } from 'vite'
 import { configDefaults } from 'vitest/config'
 
+// Plugin to replace Umami analytics placeholder in index.html with env variable
+function htmlEnvPlugin() {
+  return {
+    name: 'html-transform',
+    transformIndexHtml(html: string) {
+      return html.replace('%VITE_UMAMI_WEBSITE_ID%', process.env.VITE_UMAMI_WEBSITE_ID ?? '')
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig(() => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), htmlEnvPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## 📊 Migración a Umami Analytics

Esta PR migra el proyecto de Vercel Analytics a **Umami**, una solución de analytics autoalojada y enfocada en la privacidad.

### ✅ Cambios Implementados

#### 1. **Eliminación de Vercel Analytics**
- ❌ Desinstalados paquetes `@vercel/analytics` y `@vercel/speed-insights`
- ❌ Eliminadas importaciones de `SpeedInsights` en [main.tsx](src/main.tsx)
- ❌ Eliminado componente `<Analytics />` de [Layout.tsx](src/components/Layout.tsx)

#### 2. **Integración de Umami**
- ✅ Añadido script de tracking en [index.html](index.html)
- ✅ Creado plugin de Vite para inyectar `VITE_UMAMI_WEBSITE_ID` en [vite.config.ts](vite.config.ts)
- ✅ Añadida variable de entorno `VITE_UMAMI_WEBSITE_ID` en [.env.example](.env.example)

#### 3. **Actualización de Seguridad (CSP)**
- ✅ Actualizado CSP en [vercel.json](vercel.json) para permitir scripts de Umami
- ✅ Actualizado CSP en [src/hooks/useSecurity.ts](src/hooks/useSecurity.ts)
- ✅ Actualizado preconnect en [src/lib/resourcePreloading.ts](src/lib/resourcePreloading.ts)

#### 4. **Documentación**
- 📚 [docs/es/UMAMI_SETUP.md](docs/es/UMAMI_SETUP.md) - Guía completa en español
- 📚 [docs/en/UMAMI_SETUP.md](docs/en/UMAMI_SETUP.md) - Complete guide in English
- 📚 [docs/MIGRACION_UMAMI.md](docs/MIGRACION_UMAMI.md) - Resumen de migración

### 🚀 Próximos Pasos para Deploy

Para que funcione en producción, necesitas:

1. **Configurar variable de entorno en Dokploy:**
   ```bash
   VITE_UMAMI_WEBSITE_ID=ad557ea5-3765-488b-abf5-9ca6157422c4
   ```

2. **Reiniciar el servicio** después de añadir la variable

### 🎨 Ventajas de Umami

| Característica | Umami | Vercel Analytics |
|----------------|-------|------------------|
| **Alojamiento** | ✅ Self-hosted | ☁️ Cloud |
| **Privacidad** | ✅ 100% control | ⚠️ Terceros |
| **Cookies** | ✅ Sin cookies | ⚠️ Con cookies |
| **GDPR** | ✅ Compliant | ✅ Compliant |
| **Múltiples dominios** | ✅ Soportado | ⚠️ Limitado |
| **Costo** | ✅ Gratis (infra) | 💰 Limitado |

### 🌐 Soporte Multi-dominio

La configuración permite que múltiples dominios (`.dev`, `.es`, `.com`) reporten al mismo dashboard de Umami usando el mismo `WEBSITE_ID`.

### ✅ Testing

- ✅ Type-check pasado
- ✅ Lint-staged ejecutado correctamente
- ✅ Verificado funcionamiento en producción

### 📚 Recursos

- [Documentación oficial de Umami](https://umami.is/docs)
- [Panel de Umami](https://mywebsite-umami.mddiosc.cloud)

---

**Nota:** Esta es una breaking change ya que elimina completamente Vercel Analytics. Los datos históricos en Vercel se mantendrán, pero las nuevas métricas estarán solo en Umami.