### PR TITLE
feat(blog): add agent era hybrid LLMs and memory post in EN and ES

### DIFF
--- a/src/content/blog/en/2026-04-18-agent-era-hybrid-llms-memory.md
+++ b/src/content/blog/en/2026-04-18-agent-era-hybrid-llms-memory.md
@@ -1,0 +1,219 @@
+---
+title: 'AI agents for real development: opencode, memory, and hybrid LLMs'
+description: 'How I started using autonomous agents like opencode and rtk-ai, combined with local and cloud LLMs and persistent memory via engram, to handle full development workflows without context loss.'
+date: '2026-04-18'
+tags: ['ai', 'llm', 'agents', 'opencode', 'engram', 'local-llm', 'developer-tools', 'dx']
+author: 'Miguel Angel de Dios'
+slug: 'agent-era-hybrid-llms-memory'
+featured: false
+---
+
+## Why I stopped using AI just for autocomplete
+
+For a long time my AI usage was simple: tab to accept a suggestion, ask the chat for a snippet, copy and paste.
+
+That works. But it scales poorly.
+
+The moment a task involves more than one file, more than one decision, or more than one session — that workflow breaks. You lose context. You re-explain the same thing. You paste the same error three times.
+
+The shift that changed things for me was moving from _AI as assistant_ to _AI as agent_.
+
+---
+
+## What an agent actually means in practice
+
+Not a chatbot. Not an autocomplete.
+
+An agent is a system that takes a goal and runs a full cycle to achieve it:
+
+1. **Investigate** — reads the codebase before touching anything (`glob`, `grep`, file reads).
+2. **Plan** — breaks the goal into discrete tasks (`todo-write`), not one big prompt.
+3. **Execute** — runs commands, edits files, installs packages, runs tests.
+4. **Verify** — checks output at each step and decides whether to continue or retry.
+
+The difference: it does not stop at the suggestion. It acts.
+
+`opencode` is the tool that made this click for me. CLI-first, it navigates your project, proposes a plan, and carries it out. It asks when it needs a human call. Otherwise it keeps going.
+
+---
+
+## The memory problem
+
+Here is what breaks most agent setups: no persistent memory.
+
+Every session starts from scratch. The agent rediscovers the same patterns, hits the same walls, and has no memory of why you made a decision two hours ago. For short tasks, fine. For anything that spans sessions — a feature, a refactor, a bug hunt — it is painful.
+
+`engram` solves this.
+
+After a non-trivial discovery, the agent saves it:
+
+```bash
+mem_save \
+  --title "CORS fix on /api/auth" \
+  --type bugfix \
+  --content "What: added credentials:true in fetch and updated express CORS origin config.
+Why: Safari was silently blocking preflight requests.
+Where: src/api/server.ts, src/hooks/useAuth.ts
+Learned: Safari handles credentialed CORS differently from Chrome."
+```
+
+Next session, before starting:
+
+```bash
+mem_context --project my-app --limit 10
+mem_search "CORS auth Safari"
+```
+
+The agent now knows what was tried, what worked, and why. That is the difference between a tool and something that actually accumulates knowledge.
+
+---
+
+## RTK: cutting token usage before it becomes a problem
+
+One thing that catches you off guard when working with agents: the token bill.
+
+Agents run many commands — `git log`, `npm install`, `tsc --noEmit`, test runners. The raw output of those commands is verbose. Passing all of it to the LLM on every step is wasteful and slows the loop down.
+
+This is exactly what `rtk-ai` (RTK — Rust Token Killer) solves.
+
+RTK is a high-performance CLI proxy that sits between your commands and the LLM. It filters and compresses command output before it reaches the model — reducing token consumption by **60–90%** in practice.
+
+It integrates directly into Claude Code via a hook:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/yourname/.claude/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Once set up, every Bash command the agent runs passes through RTK automatically. You can also check how much you are saving:
+
+```bash
+rtk gain              # total token savings so far
+rtk gain --history    # per-command breakdown
+rtk discover          # find commands not yet covered by RTK
+```
+
+And if you need to debug the raw output without filtering:
+
+```bash
+rtk proxy git log --oneline -20
+```
+
+In a long agent session — investigating a codebase, running tests, checking types — RTK makes a real difference. Less noise reaching the model means faster responses, lower cost, and less context pollution.
+
+---
+
+## Hybrid LLMs: spending tokens where they matter
+
+Not every task needs the most powerful model.
+
+Running everything through Claude Opus or GPT is like hiring a senior architect to rename a variable. It works. It is also unnecessary.
+
+A practical routing setup:
+
+```json
+{
+  "models": {
+    "default": "lmstudio/qwen/qwen3.6-35b-a3b",
+    "complex": "anthropic/claude-opus-4-5",
+    "fast": "lmstudio/google/gemma-4-e4b"
+  },
+  "routing": {
+    "simple_edit": "default",
+    "architecture": "complex",
+    "explanation": "fast"
+  }
+}
+```
+
+I run local models via **LM Studio**. My current stack:
+
+| Model                                 | Params  | Use case                                              |
+| ------------------------------------- | ------- | ----------------------------------------------------- |
+| `qwen/qwen3.6-35b-a3b`                | 35B MoE | Default workhorse — good balance of quality and speed |
+| `google/gemma-4-26b-a4b`              | 26B MoE | Reasoning-heavy local tasks                           |
+| `google/gemma-4-e4b`                  | 7.5B    | Fast responses, lightweight tasks                     |
+| `mistralai/ministral-3-14b-reasoning` | 14B     | Structured reasoning, step-by-step problems           |
+| `openai/gpt-oss-20b`                  | 20B     | Code generation, currently loaded by default          |
+
+**Local models** handle:
+
+- Linting and formatting
+- Simple refactors and renames
+- Boilerplate generation
+- Anything with sensitive data that cannot leave the machine
+
+**Cloud models** take over for:
+
+- Architecture decisions
+- Multi-file refactors with complex dependencies
+- Comprehensive test generation
+- Ambiguous requirements that need real reasoning
+
+The benefit is not just cost. Local models respond in milliseconds. That keeps the agent loop tight on the simple steps.
+
+### Rough provider guide
+
+| Provider                       | Best for                                    |
+| ------------------------------ | ------------------------------------------- |
+| Claude (Anthropic)             | Long context, precise instruction-following |
+| GPT (OpenAI)                   | Speed, strong code generation               |
+| Gemini (Google)                | Research-heavy, large context               |
+| Qwen 3.6 / GPT-OSS 20B (local) | Routine tasks, private data, zero cost      |
+
+---
+
+## What a full session looks like
+
+```text
+Session start
+├── mem_context()           ← recover previous state
+├── mem_search("topic X")  ← check what we already tried
+
+├── opencode: investigate (glob, grep, file reads)
+├── opencode: plan (todo-write)
+
+└── per task:
+    ├── local LLM if simple (qwen3.6, gemma-4-e4b, gpt-oss-20b)
+    ├── Claude/GPT if complex
+    ├── execute and verify
+    └── mem_save() if something is worth keeping
+```
+
+I review the plan before execution. Approve, adjust if needed, then monitor. The cognitive load shifts from "write every line" to "define the goal clearly and review the output critically".
+
+That is a different skill. Turns out it is also more interesting.
+
+---
+
+## What actually changes
+
+This is not about replacing developers.
+
+It is about changing what you spend your time on.
+
+The skills that matter more now:
+
+- Defining goals precisely — vague prompts produce vague code
+- Reviewing output critically — trust but verify, every time
+- Designing the agent setup — tools, models, memory strategy
+- Building feedback loops — tests and CI that catch what the agent misses
+
+The agent writes the code. You write the spec, the constraints, and the quality bar.
+
+---
+
+If you want to go deeper, in a follow-up post I can share a practical setup for running `opencode` with local LM Studio models and engram memory on a real React project.

--- a/src/content/blog/es/2026-04-18-agent-era-hybrid-llms-memory.md
+++ b/src/content/blog/es/2026-04-18-agent-era-hybrid-llms-memory.md
@@ -1,0 +1,219 @@
+---
+title: 'Agentes IA para desarrollo real: opencode, memoria y LLMs híbridos'
+description: 'Como empece a usar agentes autonomos como opencode y rtk-ai, combinados con LLMs locales y cloud y memoria persistente via engram, para gestionar flujos de desarrollo completos sin perder contexto.'
+date: '2026-04-18'
+tags: ['ia', 'llm', 'agentes', 'opencode', 'engram', 'llm-local', 'herramientas-desarrollo', 'dx']
+author: 'Miguel Angel de Dios'
+slug: 'agent-era-hybrid-llms-memory'
+featured: false
+---
+
+## Por que deje de usar la IA solo para autocompletar
+
+Durante mucho tiempo mi uso de IA era simple: aceptar una sugerencia con tab, pedir un snippet al chat, copiar y pegar.
+
+Funciona. Pero escala mal.
+
+En cuanto una tarea implica mas de un archivo, mas de una decision, o mas de una sesion — ese flujo se rompe. Pierdes contexto. Vuelves a explicar lo mismo. Pegas el mismo error tres veces.
+
+El cambio que lo transformo para mi fue pasar de _IA como asistente_ a _IA como agente_.
+
+---
+
+## Lo que significa un agente en la practica
+
+No es un chatbot. No es un autocompletado.
+
+Un agente es un sistema que recibe un objetivo y ejecuta un ciclo completo para conseguirlo:
+
+1. **Investigar** — lee el codebase antes de tocar nada (`glob`, `grep`, lecturas de archivos).
+2. **Planificar** — divide el objetivo en tareas concretas (`todo-write`), no un prompt enorme.
+3. **Ejecutar** — lanza comandos, edita archivos, instala paquetes, pasa tests.
+4. **Verificar** — revisa la salida en cada paso y decide si continuar o reintentar.
+
+La diferencia clave: no se detiene en la sugerencia. Actua.
+
+`opencode` es la herramienta que hizo que esto encajase para mi. CLI-first, navega tu proyecto, propone un plan y lo ejecuta. Pregunta cuando necesita una decision humana. Si no, sigue adelante.
+
+---
+
+## El problema de la memoria
+
+Esto es lo que rompe la mayoria de setups con agentes: no tienen memoria persistente.
+
+Cada sesion empieza desde cero. El agente redescubre los mismos patrones, choca contra las mismas paredes y no recuerda por que tomaste una decision hace dos horas. Para tareas cortas, bien. Para cualquier cosa que abarque varias sesiones — una feature, una refactorizacion, una investigacion de bug — es un problema real.
+
+`engram` resuelve esto.
+
+Despues de un descubrimiento relevante, el agente lo guarda:
+
+```bash
+mem_save \
+  --title "Fix CORS en /api/auth" \
+  --type bugfix \
+  --content "What: añadido credentials:true en fetch y actualizado origin en config CORS de express.
+Why: Safari bloqueaba las peticiones preflight silenciosamente.
+Where: src/api/server.ts, src/hooks/useAuth.ts
+Learned: Safari trata CORS con credenciales diferente a Chrome."
+```
+
+En la siguiente sesion, antes de empezar:
+
+```bash
+mem_context --project my-app --limit 10
+mem_search "CORS auth Safari"
+```
+
+El agente ahora sabe que se intento, que funciono y por que. Esa es la diferencia entre una herramienta y algo que acumula conocimiento de verdad.
+
+---
+
+## RTK: recortando el consumo de tokens antes de que sea un problema
+
+Algo que te pilla desprevenido cuando trabajas con agentes: la factura de tokens.
+
+Los agentes ejecutan muchos comandos — `git log`, `npm install`, `tsc --noEmit`, runners de tests. El output bruto de esos comandos es verboso. Pasarselo todo al LLM en cada paso es un desperdicio y ralentiza el bucle.
+
+Esto es exactamente lo que resuelve `rtk-ai` (RTK — Rust Token Killer).
+
+RTK es un proxy CLI de alto rendimiento que se coloca entre tus comandos y el LLM. Filtra y comprime el output de los comandos antes de que llegue al modelo — reduciendo el consumo de tokens entre un **60–90%** en la practica.
+
+Se integra directamente en Claude Code via un hook:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/yourname/.claude/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Una vez configurado, cada comando Bash que ejecute el agente pasa por RTK automaticamente. Tambien puedes ver cuanto estas ahorrando:
+
+```bash
+rtk gain              # ahorro total de tokens hasta ahora
+rtk gain --history    # desglose por comando
+rtk discover          # encuentra comandos que RTK aun no cubre
+```
+
+Y si necesitas debuggear el output bruto sin filtrar:
+
+```bash
+rtk proxy git log --oneline -20
+```
+
+En una sesion larga de agente — investigando un codebase, pasando tests, chequeando tipos — RTK marca una diferencia real. Menos ruido llegando al modelo significa respuestas mas rapidas, menor coste y menos contaminacion del contexto.
+
+---
+
+## LLMs hibridos: gastando tokens donde importa
+
+No toda tarea necesita el modelo mas potente.
+
+Pasar todo por Claude o GPT es como contratar a un arquitecto senior para renombrar una variable. Funciona. Tambien es innecesario.
+
+Un routing practico:
+
+```json
+{
+  "models": {
+    "default": "lmstudio/qwen/qwen3.6-35b-a3b",
+    "complex": "anthropic/claude-opus-4-5",
+    "fast": "lmstudio/google/gemma-4-e4b"
+  },
+  "routing": {
+    "simple_edit": "default",
+    "architecture": "complex",
+    "explanation": "fast"
+  }
+}
+```
+
+Ejecuto los modelos locales via **LM Studio**. Mi stack actual:
+
+| Modelo                                | Params  | Uso                                                              |
+| ------------------------------------- | ------- | ---------------------------------------------------------------- |
+| `qwen/qwen3.6-35b-a3b`                | 35B MoE | Caballo de batalla principal — buen equilibrio calidad/velocidad |
+| `google/gemma-4-26b-a4b`              | 26B MoE | Tareas locales con razonamiento mas exigente                     |
+| `google/gemma-4-e4b`                  | 7.5B    | Respuestas rapidas, tareas ligeras                               |
+| `mistralai/ministral-3-14b-reasoning` | 14B     | Razonamiento estructurado, problemas paso a paso                 |
+| `openai/gpt-oss-20b`                  | 20B     | Generacion de codigo, actualmente cargado por defecto            |
+
+**Modelos locales** para:
+
+- Linting y formateo
+- Refactorizaciones y renombrados simples
+- Generacion de boilerplate
+- Cualquier cosa con datos sensibles que no puede salir de la maquina
+
+**Modelos cloud** para:
+
+- Decisiones de arquitectura
+- Refactorizaciones multi-archivo con dependencias complejas
+- Generacion de suites de tests completas
+- Requisitos ambiguos que necesitan razonamiento real
+
+El beneficio no es solo el coste. Los modelos locales responden en milisegundos. Eso mantiene el bucle del agente agil en los pasos simples.
+
+### Guia rapida de proveedores
+
+| Proveedor                      | Mejor para                                           |
+| ------------------------------ | ---------------------------------------------------- |
+| Claude (Anthropic)             | Contexto largo, seguimiento preciso de instrucciones |
+| GPT (OpenAI)                   | Velocidad, generacion de codigo solida               |
+| Gemini (Google)                | Tareas de investigacion, contexto masivo             |
+| Qwen 3.6 / GPT-OSS 20B (local) | Tareas rutinarias, datos privados, coste cero        |
+
+---
+
+## Como es una sesion completa
+
+```text
+Inicio de sesion
+├── mem_context()           ← recuperar estado anterior
+├── mem_search("tema X")   ← revisar lo que ya intentamos
+
+├── opencode: investigar (glob, grep, lecturas)
+├── opencode: planificar (todo-write)
+
+└── por tarea:
+    ├── LLM local si es simple (qwen3.6, gemma-4-e4b, gpt-oss-20b)
+    ├── Claude/GPT si es complejo
+    ├── ejecutar y verificar
+    └── mem_save() si merece guardarse
+```
+
+Reviso el plan antes de ejecutar. Apruebo, ajusto si hace falta, luego monitorizo. La carga cognitiva pasa de "escribir cada linea" a "definir el objetivo con claridad y revisar el resultado de forma critica".
+
+Es una habilidad diferente. Resulta que tambien es mas interesante.
+
+---
+
+## Lo que cambia de verdad
+
+No va de reemplazar desarrolladores.
+
+Va de cambiar en que gastas tu tiempo.
+
+Las habilidades que ahora importan mas:
+
+- Definir objetivos con precision — los prompts vagos producen codigo vago
+- Revisar el output con criterio — confiar pero verificar, siempre
+- Diseñar el setup del agente — herramientas, modelos, estrategia de memoria
+- Construir los bucles de feedback — tests y CI que pillen lo que el agente falla
+
+El agente escribe el codigo. Tu escribes la especificacion, las restricciones y el listón de calidad.
+
+---
+
+Si quieres profundizar, en un siguiente post puedo compartir un setup practico para correr `opencode` con modelos locales de LM Studio y memoria engram en un proyecto React real.


### PR DESCRIPTION
## Summary

- Adds two new bilingual blog posts (EN/ES) about the new paradigm of autonomous AI agents in software development
- Covers key topics: `opencode` agent lifecycle, `engram` persistent memory, RTK (Rust Token Killer) for token optimization, and hybrid LLM orchestration with local (LM Studio) and cloud models
- Articles follow the existing naming convention (`YYYY-MM-DD`) and frontmatter structure of the blog

## Posts added

- `src/content/blog/en/2026-04-18-agent-era-hybrid-llms-memory.md`
- `src/content/blog/es/2026-04-18-agent-era-hybrid-llms-memory.md`

## Topics covered

- Autonomous agent workflow: investigate → plan → execute → verify
- Persistent memory with `engram` (`mem_save`, `mem_context`, `mem_search`)
- RTK (Rust Token Killer): CLI proxy that reduces LLM token consumption 60–90%
- Hybrid LLM routing: local models via LM Studio (qwen3.6, gemma-4, gpt-oss-20b, ministral) vs cloud (Claude, GPT, Gemini)
- The engineer as orchestrator, not typist