### PR TITLE
perf: frontend performance quick wins

### DIFF
--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/design.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/design.md
@@ -1,0 +1,97 @@
+## Context
+
+El proyecto es un SPA estático desplegado via Nginx/Docker con React 19 + Vite 8. La auditoría de performance identificó cuatro fuentes de fricción tratables sin cambios arquitecturales:
+
+1. **ReactQueryDevtools en producción**: se renderiza incondicionalmente dentro de `StrictMode` en `src/main.tsx`, incluyendo su código (~40-80KB gzip) en el bundle de producción.
+2. **Delay artificial en useBlog**: `await new Promise((resolve) => setTimeout(resolve, 100))` en `src/hooks/useBlog.ts` retrasa la carga de blog sin valor UX.
+3. **Tema resuelto en useEffect**: `useTheme` aplica la clase `dark`/`light` después del hydrate, causando un flash de color visible.
+4. **resourcePreloading.ts sin usar**: funciones exportadas (`preloadFont`, `preinitStylesheet`, etc.) nunca se invocan desde `initializeCriticalResources`.
+
+El script `check-performance-budget.mjs` ya vigila chunks gzip. Lighthouse CI ya tiene assertions. No hay SSR.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminar ReactQueryDevtools del bundle de producción
+- Eliminar delay artificial en blog
+- Resolver el tema antes del primer paint para eliminar flash de color
+- Activar preconnect/prefetch estático en index.html para terceros
+- Detectar y conectar o eliminar funciones huérfanas en resourcePreloading.ts
+
+**Non-Goals:**
+
+- No migrar a SSR ni introduce frameworks de rendering
+- No modificar la lógica de routing ni i18n
+- No cambiar la arquitectura de estado (Context + React Query se mantienen)
+- No implementar service workers ni caching strategies
+- No tocar animaciones, CLS por layout shift u otras optimizaciones de runtime
+
+## Decisions
+
+### D1: Condicionalizar Devtools con `import.meta.env.DEV`
+
+**Decisión**: Envolver `<ReactQueryDevtools />` con `import.meta.env.DEV`.
+
+**Alternativas**:
+
+- `process.env.NODE_ENV !== 'production'`: no funciona igual en Vite — los builds de Vite usan `import.meta.env` globals, no `process.env`.
+- Build plugin de Rollup para eliminar el import: overkill para una línea.
+
+**rationale**: Vite ya define `import.meta.env.DEV = true` solo en dev. En preview/build es `false`. El tree-shaking de Rolldown elimina el código del branch muerto en producción.
+
+### D2: Script inline de tema como primer elemento en `<head>`
+
+**Decisión**: Insertar un IIFE síncrono en `index.html` como primer hijo de `<head>` (antes de cualquier `<link>` o `<script>`) que lea `localStorage`, resuelva `system` con `matchMedia`, y aplique `dark` o `light` a `<html>`.
+
+**Alternativas**:
+
+- Inline style en `<html>` con valor por defecto: no resuelve `system`, siempre需要一个 fallback fijo.
+- CSS custom property en `:root`: la clase `.dark` en `<html>` es el mecanismo actual; replicar con CSS variable requiere cambiar la estrategia de tema existente.
+- `React 19 useId` + blocking resource: no aplica — el tema es síncrono.
+
+**rationale**: El script síncrono garantiza que cuando React hydrate, la clase ya está aplicada. No hay flash porque no hay intervalo entre página blanca y color resuelto.
+
+### D3: useTheme no duplica trabajo cuando la clase ya existe
+
+**Decisión**: `useTheme` verifica en su inicialización si `<html>` ya tiene la clase `dark` o `light`. Si la tiene (aplicada por el script inline), usa ese valor como estado inicial sin escribir en localStorage ni volver a aplicar la clase.
+
+**Alternativas**:
+
+- Eliminar el `classList.add/remove` de `useTheme`: rompería el cambio de tema en runtime.
+- Hacer que `useTheme` solo lea y never escriba: el toggle de tema necesita escribir.
+
+**rationale**: El script inline ya hizo el trabajo de arranque. `useTheme` puede leer el estado actual sin necesidad de re-aplicarlo si ya está correcto.
+
+### D4: preconnect estático en index.html
+
+**Decisión**: Añadir `<link rel="preconnect">` para google fonts, gstatic, formspree, umami dentro del `<head>` existente, complementando lo que `preconnectToOrigins()` hace en runtime.
+
+**Alternativas**:
+
+- Solo runtime via `preconnectToOrigins()`: ya se llama desde `initializeCriticalResources()`, pero solo después de que React carga. Los hints estáticos resuelven antes.
+- Vite plugin para inyectar hints: innecesario — es HTML estático.
+
+**rationale**: El HTML estático es lo primero que llega. Los hints de preconnect早点 aplican, reducen DNS/TLS handshake time para terceros.
+
+### D5: Auditoria de resourcePreloading.ts
+
+**Decisión**: Recorrer todos los exports de `src/lib/resourcePreloading.ts` y verificar cuáles tienen callers en el codebase. Los que no tengan se marcan como dead code o se conectan donde aplique (por ejemplo, `preloadImage` para el logo del navbar).
+
+**Alternativas**:
+
+- Eliminar todo sin usar: perdería funciones que podrían tener uso futuro.
+- Dejar como está: ensucia el codebase.
+
+**rationale**: Un cambio pequeño pero de mantenimiento — mantener la utilidad coherente con su uso real.
+
+## Risks / Trade-offs
+
+- **[Riesgo] Tema inline puede desfasarse con localStorage**: si el usuario cambia el tema en otra pestaña y luego vuelve, el script inline siempre leerá el valor original. **Mitigación**: el script solo aplica al奶油 inicial. Los cambios en runtime son manejados por `useTheme` como antes. No hay conflicto.
+- **[Riesgo] Quitar el delay de blog puede hacer imperceptible el loading state**: si el tiempo de carga real es menor que 100ms, el spinner parpadea. **Mitigación**: verificar con Playwright que el estado de carga se renderiza y desaparece correctamente.
+- **[Riesgo] Devtools eliminado afecta debugging en staging**: si alguien quiere inspeccionar queries en staging. **Mitigación**: staging es `import.meta.env.DEV = false` por defecto en preview. Para debugging real, se puede usar `pnpm dev`.
+
+## Open Questions
+
+- **¿Hay imágenes hero que requieran `preloadImage` de React 19?** La auditoría no inspeccionó `src/assets`. Se asume que si las hay, se agregarán en una fase posterior. Este change no las incluye.
+- **¿El script inline de tema debealso also apply `data-theme` attribute?** El sistema actual usa clase `.dark`/`.light`. No se debe cambiar a `data-theme` a menos que haya una razón. El script usa clases para mantener compatibilidad.

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/proposal.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+El proyecto tiene una base sólida de performance (lazy routes, vendor split, budgets gzip, Lighthouse CI), pero durante una auditoría se identificaron fricciones medibles en arranque, runtime y render que penalizan métricas de Core Web Vitals sin aportar valor al usuario. Estas son correcciones locales, de bajo riesgo y alto impacto que pueden validarse con la infraestructura existente.
+
+## What Changes
+
+- Excluir `ReactQueryDevtools` del bundle de producción en `src/main.tsx`
+- Eliminar el delay artificial de 100ms en `src/hooks/useBlog.ts`
+- Añadir `preconnect` estático en `index.html` para Google Fonts, gstatic, formspree y umami
+- Implementar script inline de tema en `index.html` para eliminar flash de tema antes del primer paint
+- Ajustar `useTheme` para evitar trabajo duplicado si el tema ya está aplicado por el script inline
+- Conectar funciones de `src/lib/resourcePreloading.ts` que hoy no tienen callers o verificar cuáles están huérfanas
+
+## Capabilities
+
+### New Capabilities
+
+- `performance-boot-optimization`: optimizaciones de arranque que reducen bundle innecesario, eliminan delays artificiales y mejoran LCP/CLS sin cambios arquitecturales
+- `theme-anti-flash`: estrategia de script inline en `index.html` que resuelve el tema antes del primer paint, eliminando el flash de color
+- `resource-hints-activation`: uso efectivo de `preconnect`/`dns-prefetch` estáticos en el HTML para terceros conocidos
+
+### Modified Capabilities
+
+- Ninguna — todas las capacidades son optimizations del estado actual, no cambios de requisito
+
+## Impact
+
+- **Código afectado**: `src/main.tsx`, `src/hooks/useBlog.ts`, `index.html`, `src/hooks/useTheme.ts`, `src/lib/resourcePreloading.ts`
+- **Métricas esperadas**: mejora en Lighthouse performance score (objetivo ≥ 0.70 desde 0.65), reducción de TTI, eliminación de CLS por flash de tema
+- **Dependencias**: ninguna nueva; usa infraestructura existente (`performance:budget`, Lighthouse CI, Vitest, Playwright)
+- **No afecta**: routing, i18n, contenido, APIs, formas de contacto, SEO metadata existente

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/performance-boot-optimization/spec.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/performance-boot-optimization/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: ReactQueryDevtools excluded from production bundle
+
+The system SHALL NOT include `@tanstack/react-query-devtools` in any production build artifact.
+
+#### Scenario: Devtools absent in production build
+
+- **WHEN** the application is built with `pnpm build` for preview or deployment
+- **THEN** the resulting JavaScript bundles SHALL NOT contain the `ReactQueryDevtools` component or its dependencies
+- **AND** `import.meta.env.DEV` evaluates to `false` in that build context
+
+#### Scenario: Devtools present during development
+
+- **WHEN** the application runs with `pnpm dev`
+- **THEN** `ReactQueryDevtools` SHALL be rendered and accessible for query inspection
+
+---
+
+### Requirement: No artificial delay in blog data loading
+
+The system SHALL NOT introduce any manual `setTimeout` delay when loading blog posts.
+
+#### Scenario: Blog posts load at actual data speed
+
+- **WHEN** the user navigates to the blog page
+- **THEN** blog posts SHALL be displayed as soon as the underlying `import.meta.glob` resolution completes
+- **AND** no artificial delay SHALL be inserted between data resolution and render
+
+---
+
+### Requirement: Production build passes performance budget checks
+
+The system SHALL ensure that after applying all boot optimizations, all chunk budgets defined in `scripts/check-performance-budget.mjs` continue to pass.
+
+#### Scenario: Performance budget script passes after changes
+
+- **WHEN** `pnpm performance:budget` is executed after the changes
+- **THEN** every chunk SHALL report a gzip size within its defined limit
+- **AND** the script exit code SHALL be 0

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/resource-hints-activation/spec.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/resource-hints-activation/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Preconnect hints present in static HTML
+
+The system SHALL include `<link rel="preconnect">` hints in `index.html` for all known third-party origins used at runtime.
+
+#### Scenario: Google Fonts preconnect hints present
+
+- **WHEN** `index.html` is served to the browser
+- **THEN** it SHALL contain `<link rel="preconnect">` for `https://fonts.googleapis.com`
+- **AND** it SHALL contain `<link rel="preconnect" crossorigin>` for `https://fonts.gstatic.com`
+
+#### Scenario: Formspree preconnect hint present
+
+- **WHEN** `index.html` is served to the browser
+- **THEN** it SHALL contain `<link rel="preconnect">` for `https://formspree.io`
+
+#### Scenario: Umami analytics preconnect hint present
+
+- **WHEN** `index.html` is served to the browser
+- **THEN** it SHALL contain `<link rel="preconnect">` for `https://mywebsite-umami.mddiosc.cloud`
+
+---
+
+### Requirement: resourcePreloading.ts exports are connected or removed
+
+The system SHALL ensure that every function exported from `src/lib/resourcePreloading.ts` is either called somewhere in the application or explicitly marked as available for future use.
+
+#### Scenario: All resourcePreloading exports have callers or are documented
+
+- **WHEN** the code is audited
+- **THEN** each exported function SHALL have at least one call site in the codebase
+- **OR** the function SHALL be retained with a clear comment indicating it is intended for future use
+
+#### Scenario: No dead exports remain in resourcePreloading.ts
+
+- **WHEN** `src/lib/resourcePreloading.ts` is reviewed
+- **THEN** no function SHALL be exported without a corresponding invocation or documented intent

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/theme-anti-flash/spec.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/specs/theme-anti-flash/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Theme class applied before first paint
+
+The system SHALL apply the resolved theme class (`dark` or `light`) to `<html>` synchronously before the browser paints the page.
+
+#### Scenario: Theme resolved from localStorage on page load
+
+- **WHEN** a user loads the page with a stored theme preference of `"dark"` in localStorage
+- **THEN** the `<html>` element SHALL have the class `dark` before any visual paint occurs
+- **AND** no white flash SHALL be visible during page load
+
+#### Scenario: Theme resolved from system preference when no stored preference
+
+- **WHEN** a user loads the page with no theme stored in localStorage and system prefers dark mode
+- **THEN** the `<html>` element SHALL have the class `dark` before any visual paint occurs
+
+#### Scenario: Light theme applied when system prefers light
+
+- **WHEN** a user loads the page with no theme stored and system prefers light mode
+- **THEN** the `<html>` element SHALL have the class `light` before any visual paint occurs
+
+---
+
+### Requirement: useTheme does not duplicate class application on init
+
+The `useTheme` hook SHALL detect when the theme class is already correctly applied to `<html>` and SHALL NOT re-apply it or overwrite localStorage during initialization.
+
+#### Scenario: Theme already matches stored preference
+
+- **WHEN** `useTheme` initializes and `<html>` already has the class matching the stored preference
+- **THEN** the hook SHALL set its internal state to that theme value
+- **AND** the hook SHALL NOT write to localStorage during that initialization
+
+#### Scenario: Theme class missing despite stored preference
+
+- **WHEN** `useTheme` initializes and `<html>` lacks a theme class but localStorage has a stored value
+- **THEN** the hook SHALL apply the correct class to `<html>`
+- **AND** the hook SHALL update its internal state accordingly
+
+#### Scenario: Runtime theme toggle still works
+
+- **WHEN** the user clicks the theme toggle button at runtime (after initial load)
+- **THEN** `useTheme` SHALL update the `<html>` class
+- **AND** `useTheme` SHALL persist the new preference to localStorage

--- a/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/tasks.md
+++ b/openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/tasks.md
@@ -1,0 +1,47 @@
+## 1. Branch Setup
+
+- [ ] 1.1 Create branch `chore/frontend-performance-quick-wins` from `main`
+
+## 2. Performance Boot Optimization
+
+- [ ] 2.1 Condicionalize ReactQueryDevtools in `src/main.tsx`
+  - Wrap `<ReactQueryDevtools initialIsOpen={false} />` with `import.meta.env.DEV &&`
+- [ ] 2.2 Remove artificial delay from `src/hooks/useBlog.ts`
+  - Delete `await new Promise((resolve) => setTimeout(resolve, 100))`
+- [ ] 2.3 Verify production bundle excludes devtools
+  - Run `pnpm build && pnpm performance:budget`
+
+## 3. Theme Anti-Flash
+
+- [ ] 3.1 Read current `index.html` to locate `</head>` position
+- [ ] 3.2 Add synchronous theme-init IIFE as first child of `<head>` in `index.html`
+  - Reads `localStorage.getItem('theme-preference')`
+  - Resolves `system` via `window.matchMedia('(prefers-color-scheme: dark)')`
+  - Applies `dark` or `light` class to `<html>` element
+- [ ] 3.3 Update `src/hooks/useTheme.ts` to detect existing class on init
+  - On initialization, check if `<html>` already has the correct theme class
+  - If class exists, use it as initial state without writing to localStorage
+  - If class is missing, apply it and persist as before
+- [ ] 3.4 Verify no theme flash on page reload with dark preference stored
+- [ ] 3.5 Verify runtime theme toggle still works correctly
+
+## 4. Resource Hints Activation
+
+- [ ] 4.1 Add static `<link rel="preconnect">` hints to `index.html`
+  - `https://fonts.googleapis.com`
+  - `https://fonts.gstatic.com` with `crossorigin`
+  - `https://formspree.io`
+  - `https://mywebsite-umami.mddiosc.cloud`
+- [ ] 4.2 Audit `src/lib/resourcePreloading.ts` exports
+  - List all exported functions
+  - For each: check if it has callers in the codebase
+  - Connect orphaned functions where appropriate, or mark as intended-for-future-use with comment
+- [ ] 4.3 Verify preconnect hints are present in served HTML
+
+## 5. Validation
+
+- [ ] 5.1 Run `pnpm test` and ensure all tests pass
+- [ ] 5.2 Run `pnpm build && pnpm performance:budget` and ensure all budgets pass
+- [ ] 5.3 Run `pnpm lighthouse:ci` and verify performance score ≥ 0.65
+- [ ] 5.4 Run `pnpm test:e2e` smoke suite and verify no regressions
+- [ ] 5.5 Verify no theme flash on cold load (manual or Playwright screenshot)


### PR DESCRIPTION
## Summary
- Condicionalizar ReactQueryDevtools en production (import.meta.env.DEV)
- Remover delay artificial de 100ms en blog loading
- Implementar theme anti-flash via IIFE sincrono en index.html
- Añadir preconnect hints para Google Fonts, Formspree, Umami
- Documentar exports huérfanos en resourcePreloading.ts como future-use

## Validation
- Tests unitarios: 142 passed
- E2E: 120 passed (24 skipped)
- Performance budgets: todos PASS

## Change
OpenSpec change archivado en `openspec/changes/archive/2026-05-02-frontend-performance-quick-wins/`