### PR TITLE
feat(blog): add Vectos performance post

### DIFF
--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -1,0 +1,149 @@
+import { isValidElement, type ReactElement, type ReactNode } from 'react'
+
+interface MarkdownTableProps {
+  readonly children?: ReactNode
+}
+
+interface TableCell {
+  readonly content: ReactNode
+  readonly key: string
+  readonly text: string
+}
+
+interface TableRow {
+  readonly cells: TableCell[]
+  readonly key: string
+}
+
+function toNodeArray(node: ReactNode): ReactNode[] {
+  if (Array.isArray(node)) {
+    return node.flatMap(toNodeArray)
+  }
+
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return []
+  }
+  return [node]
+}
+
+function uniqueKey(base: string, seen: Map<string, number>): string {
+  const normalizedBase = base.trim() || 'empty'
+  const count = seen.get(normalizedBase) ?? 0
+  seen.set(normalizedBase, count + 1)
+
+  return count === 0 ? normalizedBase : `${normalizedBase}-${String(count)}`
+}
+
+function getNodeText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getNodeText).join(' ')
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getNodeText(node.props.children)
+  }
+
+  return ''
+}
+
+function collectRows(node: ReactNode): TableRow[] {
+  const rows: TableRow[] = []
+  const seenRows = new Map<string, number>()
+
+  for (const child of toNodeArray(node)) {
+    if (!isValidElement<{ children?: ReactNode }>(child)) {
+      continue
+    }
+
+    if (child.type !== 'tr') {
+      rows.push(...collectRows(child.props.children))
+      continue
+    }
+
+    const seenCells = new Map<string, number>()
+    const cells = toNodeArray(child.props.children)
+      .filter((cell): cell is ReactElement<{ children?: ReactNode }> => isValidElement(cell))
+      .map((cell) => {
+        const text = getNodeText(cell.props.children)
+
+        return {
+          content: cell.props.children,
+          key: uniqueKey(text, seenCells),
+          text,
+        }
+      })
+
+    if (cells.length > 0) {
+      const rowText = cells.map((cell) => cell.text).join('|')
+      rows.push({ cells, key: uniqueKey(rowText, seenRows) })
+    }
+  }
+
+  return rows
+}
+
+export function MarkdownTable({ children }: MarkdownTableProps) {
+  const [headerRow, ...rows] = collectRows(children)
+  const headers = headerRow?.cells ?? []
+
+  return (
+    <div className="not-prose my-6">
+      <div className="hidden overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow-sm sm:block dark:border-gray-700 dark:bg-gray-900/60">
+        <table className="w-full table-auto border-separate border-spacing-0 text-left text-sm text-gray-700 dark:text-gray-200 [&_td:nth-child(2)]:whitespace-nowrap [&_td:nth-child(3)]:whitespace-nowrap">
+          {children}
+        </table>
+      </div>
+
+      <div className="space-y-3 sm:hidden">
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900/60"
+          >
+            {row.cells.map((cell, cellIndex) => (
+              <div
+                key={cell.key}
+                className="border-b border-gray-100 py-2 first:pt-0 last:border-b-0 last:pb-0 dark:border-gray-800"
+              >
+                <div className="mb-1 text-[0.68rem] font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  {headers[cellIndex]?.text ?? `Columna ${String(cellIndex + 1)}`}
+                </div>
+                <div className="text-sm leading-relaxed text-gray-800 dark:text-gray-200">
+                  {cell.content}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function MarkdownTableHead({ children }: MarkdownTableProps) {
+  return (
+    <thead className="bg-gray-50 text-xs tracking-wide text-gray-600 uppercase dark:bg-gray-800/80 dark:text-gray-300">
+      {children}
+    </thead>
+  )
+}
+
+export function MarkdownTableHeader({ children }: MarkdownTableProps) {
+  return (
+    <th className="border-b border-gray-200 px-4 py-3 font-semibold first:rounded-tl-2xl last:rounded-tr-2xl dark:border-gray-700">
+      {children}
+    </th>
+  )
+}
+
+export function MarkdownTableCell({ children }: MarkdownTableProps) {
+  return (
+    <td className="border-b border-gray-100 px-4 py-3 align-top leading-relaxed last:min-w-64 dark:border-gray-800">
+      {children}
+    </td>
+  )
+}

--- a/src/content/blog/en/2026-05-16-vectos-performance-token-efficiency-agents.md
+++ b/src/content/blog/en/2026-05-16-vectos-performance-token-efficiency-agents.md
@@ -1,0 +1,267 @@
+---
+title: 'Vectos: performance improvements and token efficiency for agents'
+description: 'A follow-up to the first Vectos post: what changed in the retrieval layer, what the benchmarks show, and why token efficiency matters so much when working with agents on real repositories.'
+date: '2026-05-16'
+tags: ['ai', 'llm', 'agents', 'embeddings', 'rag', 'vectos', 'mcp', 'performance', 'tokens', 'dx']
+author: 'Miguel Angel de Dios'
+slug: 'vectos-performance-token-efficiency-agents'
+featured: true
+---
+
+## From intuition to measurement
+
+In the first post about `Vectos`, I explained the core idea: a local semantic retrieval layer that helps agents find relevant code earlier instead of spending so much context getting oriented badly.
+
+At that point the thesis was clear, but it was still closer to an intuition validated through real usage than to a systematic measurement.
+
+Since then I have been working on exactly that part: improving retrieval, comparing against traditional tools, and measuring the real token cost more carefully.
+
+The short version is this:
+
+> Vectos is not only trying to find better results. It is trying to make the agent read less before it can decide better.
+
+That difference matters a lot.
+
+Because in an agent workflow, the cost is not only the first search. It is everything that follows: noisy results, unnecessary reads, wasted context, and reasoning built on mediocre signals.
+
+---
+
+## What changed in retrieval
+
+The first useful version of Vectos could already index a project, generate embeddings, and search by intent. It worked, but the architecture was still fairly direct:
+
+```text
+embedding -> cosine similarity -> results
+```
+
+The current version has moved toward a more hybrid stack:
+
+```text
+jina-embeddings-v3 -> HNSW -> BM25 -> RRF -> compact preview
+```
+
+In practical terms:
+
+- `jina-embeddings-v3` provides `1024`-dimensional embeddings for code, text, and multilingual queries.
+- `HNSW` avoids relying on linear vector search as the index grows.
+- `BM25` adds classic text retrieval for specific terms.
+- `RRF` fuses semantic and textual signals without forcing a single ranking source.
+- The compact preview returns paths, ranges, signatures, and hints instead of dumping entire files.
+
+This does not make Vectos magic. But it changes the ergonomics for the agent quite a bit: instead of receiving a wall of literal matches, it gets a short list of candidates with enough context to decide whether it needs to read more.
+
+---
+
+## The number I care about: total workflow cost
+
+Comparing only the cost of a search can be misleading.
+
+`glob` can return very few tokens, but it usually cannot answer anything by itself. It tells you which files might exist, not which part satisfies the intent.
+
+`grep` can be exact, but when terms are generic it returns a lot of noise. In Tailwind repositories, a query like `dark mode` can end up matching hundreds of `dark:*` classes that have nothing to do with the actual toggle implementation.
+
+`ast-grep` is very powerful for structural patterns, but it does not understand a conceptual question like “how does language switching work” unless you already know which pattern to search for.
+
+So I started measuring the complete cost:
+
+```text
+search + follow-up reads needed to answer
+```
+
+In a benchmark with ten real queries against a React/TypeScript project with Tailwind, i18n, routing, and documentation, the average numbers looked like this:
+
+| Workflow | Average tokens per query |
+| --- | ---: |
+| Vectos | ~489 |
+| grep + reads | ~8,183 |
+| glob + reads | ~3,299 |
+| ast-grep + reads | ~1,748 |
+| Read file, already knowing what to read | ~3,397 |
+
+The practical readout: in that scenario, Vectos reduced total workflow cost by about `17x` versus `grep`, `7x` versus `glob + read`, and `4x` versus `ast-grep + read`.
+
+I do not treat those ratios as universal law. I do treat them as a strong signal of where the savings come from: not from “cheaper search,” but from cutting the exploration tree earlier.
+
+---
+
+## Why grep breaks down with generic terms
+
+`grep` is still an excellent tool.
+
+If I am searching for a unique identifier, a concrete import, an error code, or an exact literal, I usually want `grep`. There is no need to overengineer that.
+
+The problem appears when the agent does not yet know the system's exact words.
+
+Examples from the benchmark:
+
+| Intent | Vectos | grep | Source of noise |
+| --- | ---: | ---: | --- |
+| Dark mode / theme toggle | ~150 tokens | ~7,956 tokens | `335` matches from Tailwind `dark:*` classes |
+| Form validation and errors | ~155 tokens | ~7,729 tokens | `error`, `form`, and `validation` appear everywhere |
+| Internationalization | ~170 tokens | ~6,355 tokens | locale keys, strings, and helpers mixed together |
+| Routing and navigation | ~145 tokens | ~4,611 tokens | `Link`, `route`, and `navigate` spread across templates |
+
+This is where a scoped semantic search helps most: when the intent is clear, but the exact words are not.
+
+In that situation, I do not want the agent processing `300` lines just to discover that the relevant implementation was in one hook and one small component. I want it to start there.
+
+---
+
+## What signatures and hints add
+
+One improvement that looks small but changes the workflow a lot is the output shape.
+
+Vectos should not only return “this file looks relevant.” That forces the agent to read too early.
+
+So the result tries to include compact signals:
+
+- file path
+- line range
+- relevant signatures or symbols
+- hints about why the result may matter
+- separation between code search and documentation search
+
+In the benchmark, roughly half of the Vectos queries provided enough context in the result itself to avoid an immediate follow-up read.
+
+That matters because the savings compound:
+
+```text
+less search output
++ fewer follow-up reads
++ fewer tool calls
++ more free context for reasoning
+```
+
+Measured as a full ten-query session, the pattern looked like this:
+
+| Workflow | Estimated session cost |
+| --- | ---: |
+| grep + reads | ~85,800 tokens |
+| glob + reads | ~36,960 tokens |
+| Vectos + targeted reads | ~11,390 tokens |
+
+That `~87%` reduction versus a `grep`-based workflow does not come from one optimization. It comes from avoiding work the agent should not need to do in the first place.
+
+---
+
+## Documentation is another place where it shows
+
+Documentation search has a similar problem.
+
+Markdown files are often long, mix guides, references, decisions, and examples, and a text search can find too many matches without pointing to the right section.
+
+That is why Vectos keeps a separate docs index:
+
+```bash
+vectos index . --docs
+vectos search --docs "how to run tests"
+```
+
+In measurements over bilingual documentation, conceptual queries also showed large differences:
+
+| Intent | Vectos | grep |
+| --- | ---: | ---: |
+| Testing strategy | ~115 tokens | ~6,418 tokens |
+| Internationalization | ~120 tokens | ~5,419 tokens |
+| Component architecture | ~120 tokens | ~3,039 tokens |
+| Development setup | ~113 tokens | ~1,050 tokens |
+| Recaptcha security | ~130 tokens | ~450 tokens |
+
+The `recaptcha` case is interesting because it shows the limit: when the term is very specific, `grep` already performs quite well. Vectos still returns less noise, but the difference is no longer spectacular.
+
+That is healthy. The tool does not need to win everywhere. It needs to win where the real workflow hurts.
+
+---
+
+## Performance is not only tokens
+
+There is also a raw performance side.
+
+Moving from linear vector search to `HNSW` changes how much room the index has to grow. In small projects it may not matter much, but it is a necessary decision if I want Vectos to be useful in medium repositories or monorepos.
+
+The MCP payload matters too. An agent does not consume an idealized table; it consumes a real tool response. In a representative check inside the Vectos repository itself, a `3`-result payload measured around `1242 bytes`; with `5` results, `1966 bytes`; with `10`, `3818 bytes`.
+
+The practical conclusion is simple: result count scales almost linearly. Keeping the default window at `5` results is a good balance between coverage and cost.
+
+More results do not always mean better context. Sometimes they only mean more pending decisions for the agent.
+
+---
+
+## Where I would not use Vectos
+
+The more I use it, the clearer it becomes that Vectos should not try to replace every tool.
+
+I would use `grep` for:
+
+- exact strings
+- concrete imports
+- unique IDs
+- error codes
+- regex patterns
+
+I would use `glob` for:
+
+- discovering files by name
+- listing `*.spec.ts`
+- finding folder conventions
+
+I would use `ast-grep` for:
+
+- structural refactors
+- finding usages of a concrete API
+- locating repeated AST patterns
+
+I would use `Vectos` when the question is closer to:
+
+- “where is this flow implemented”
+- “what controls this experience”
+- “how does this feature connect”
+- “which docs explain this decision”
+- “where should I start reading”
+
+That boundary matters to me because it keeps Vectos from becoming a generic tool without focus. Its value is orientation, not replacing every system primitive.
+
+---
+
+## What this changes in my workflow
+
+The clearest improvement is not that every search is perfect.
+
+The improvement is that the agent starts better.
+
+And when an agent starts better:
+
+- it reads less garbage
+- it uses less context
+- it makes fewer exploration calls
+- it reaches the right file earlier
+- it leaves more tokens for reasoning, editing, and verification
+
+That is why I keep investing in Vectos.
+
+Not because embeddings are interesting on their own. But because a huge part of agent work is translating a human intention into the right point in the codebase.
+
+If that translation improves, the whole workflow improves.
+
+---
+
+## Next focus
+
+After these measurements, the priorities are clearer:
+
+- keep improving hybrid ranking quality
+- refine previews so they answer more without forcing file reads
+- keep MCP payloads small
+- make incremental reindexing increasingly invisible
+- keep validating against real repositories, not just convenient fixtures
+
+Vectos is still experimental, but I no longer see it only as a promising intuition. I now have better data to explain why this layer makes sense.
+
+Agents do not need more context by default.
+
+They need better orientation before spending context.
+
+_Related:_
+
+- [Vectos: what it is, how it works, and why I am building it](/en/blog/2026-04-25-vectos-semantic-code-retrieval-agents)
+- [Why memory is not enough for working with agents on real code](/en/blog/2026-04-24-unified-memory-code-embeddings-local)

--- a/src/content/blog/es/2026-05-16-vectos-performance-token-efficiency-agents.md
+++ b/src/content/blog/es/2026-05-16-vectos-performance-token-efficiency-agents.md
@@ -1,0 +1,267 @@
+---
+title: 'Vectos: mejoras de rendimiento y eficiencia de tokens para agentes'
+description: 'Continuación del primer post sobre Vectos: qué ha cambiado en la capa de recuperación, qué muestran los benchmarks y por qué la eficiencia de tokens importa tanto cuando trabajas con agentes sobre repos reales.'
+date: '2026-05-16'
+tags: ['ia', 'llm', 'agentes', 'embeddings', 'rag', 'vectos', 'mcp', 'rendimiento', 'tokens', 'dx']
+author: 'Miguel Angel de Dios'
+slug: 'vectos-performance-token-efficiency-agents'
+featured: true
+---
+
+## De la intuición a la medición
+
+En el primer post sobre `Vectos` contaba la idea base: una capa local de recuperación semántica para que los agentes encuentren antes el código relevante y dejen de gastar tanto contexto en orientarse mal.
+
+En ese momento la tesis era bastante clara, pero todavía estaba más cerca de una intuición validada por uso real que de una medición sistemática.
+
+Desde entonces he estado trabajando justo en esa parte: mejorar la recuperación, comparar contra herramientas tradicionales y medir mejor el coste real en tokens.
+
+El resumen corto es este:
+
+> Vectos no solo intenta encontrar mejor. Intenta que el agente necesite leer menos para poder decidir mejor.
+
+Esa diferencia importa mucho.
+
+Porque en un flujo con agentes, el coste no está solo en la búsqueda inicial. Está en todo lo que viene después: resultados ruidosos, lecturas innecesarias, contexto desperdiciado y razonamiento construido sobre señales mediocres.
+
+---
+
+## Qué ha cambiado en la recuperación
+
+La primera versión útil de Vectos ya permitía indexar un proyecto, generar embeddings y buscar por intención. Funcionaba, pero todavía era una arquitectura bastante directa:
+
+```text
+embedding -> similitud coseno -> resultados
+```
+
+La versión actual ha evolucionado hacia una pila más híbrida:
+
+```text
+jina-embeddings-v3 -> HNSW -> BM25 -> RRF -> preview compacto
+```
+
+Traducido:
+
+- `jina-embeddings-v3` aporta embeddings de `1024` dimensiones, orientados a código, texto y consultas multilingües.
+- `HNSW` evita depender de una búsqueda vectorial lineal a medida que el índice crece.
+- `BM25` añade recuperación textual clásica para términos específicos.
+- `RRF` fusiona señales semánticas y textuales sin obligar a elegir una sola fuente de ranking.
+- El preview compacto devuelve rutas, rangos, firmas y pistas en lugar de volcar archivos enteros.
+
+Esto no convierte a Vectos en magia. Pero sí cambia bastante la ergonomía del agente: en vez de recibir una pared de coincidencias literales, recibe una lista corta de candidatos con suficiente contexto para decidir si necesita leer más.
+
+---
+
+## El dato que más me interesa: coste total del workflow
+
+Comparar solo el coste de una búsqueda puede ser engañoso.
+
+`glob` puede devolver pocos tokens, pero normalmente no responde nada por sí solo. Te dice qué archivos podrían existir, no qué parte resuelve la intención.
+
+`grep` puede ser exacto, pero cuando los términos son genéricos devuelve muchísimo ruido. En repos con Tailwind, buscar algo como `dark mode` puede acabar encontrando cientos de clases `dark:*` que no tienen nada que ver con la implementación del toggle.
+
+`ast-grep` es muy potente para patrones estructurales, pero no entiende una pregunta conceptual como “cómo funciona el cambio de idioma” si no sabes ya qué patrón buscar.
+
+Por eso empecé a medir el coste completo:
+
+```text
+búsqueda + lecturas posteriores necesarias para responder
+```
+
+En un benchmark con diez consultas reales sobre un proyecto React/TypeScript con Tailwind, i18n, routing y documentación, los números medios quedaron así:
+
+| Flujo | Tokens medios por consulta |
+| --- | ---: |
+| Vectos | ~489 |
+| grep + lecturas | ~8.183 |
+| glob + lecturas | ~3.299 |
+| ast-grep + lecturas | ~1.748 |
+| Read file, sabiendo ya qué leer | ~3.397 |
+
+La lectura práctica: en ese escenario, Vectos redujo el coste total del workflow unas `17x` frente a `grep`, `7x` frente a `glob + read` y `4x` frente a `ast-grep + read`.
+
+No interpreto esos ratios como una ley universal. Sí los interpreto como una señal fuerte de dónde está el ahorro real: no en “buscar más barato”, sino en cortar antes el árbol de exploración.
+
+---
+
+## Por qué grep se rompe con términos genéricos
+
+`grep` sigue siendo una herramienta excelente.
+
+Si busco un identificador único, un import concreto, un error code o un literal exacto, normalmente quiero `grep`. No hay que sobrediseñar eso.
+
+El problema aparece cuando el agente no sabe todavía cuáles son las palabras exactas del sistema.
+
+Ejemplos del benchmark:
+
+| Intención | Vectos | grep | Motivo del ruido |
+| --- | ---: | ---: | --- |
+| Dark mode / theme toggle | ~150 tokens | ~7.956 tokens | `335` matches por clases `dark:*` de Tailwind |
+| Form validation and errors | ~155 tokens | ~7.729 tokens | `error`, `form` y `validation` aparecen en demasiados sitios |
+| Internationalization | ~170 tokens | ~6.355 tokens | claves de locale, strings y helpers mezclados |
+| Routing and navigation | ~145 tokens | ~4.611 tokens | `Link`, `route`, `navigate` repartidos por templates |
+
+Este es el caso donde una búsqueda semántica bien acotada aporta más: cuando la intención está clara, pero las palabras exactas todavía no.
+
+Ahí no quieres que el agente procese `300` líneas para descubrir que la implementación relevante estaba en un hook y un componente pequeño. Quieres que empiece por esos dos sitios.
+
+---
+
+## Lo que aportan las firmas y los hints
+
+Una mejora que parece pequeña pero afecta mucho al flujo es el formato de salida.
+
+Vectos no debería devolver solo “este archivo parece relevante”. Eso obliga al agente a leer demasiado pronto.
+
+Por eso el resultado intenta incluir señales compactas:
+
+- ruta del archivo
+- rango de líneas
+- firmas o símbolos relevantes
+- hints de por qué ese resultado puede importar
+- separación entre búsqueda de código y búsqueda de documentación
+
+En el benchmark, aproximadamente la mitad de las consultas con Vectos ofrecieron suficiente contexto en el propio resultado como para evitar una lectura adicional inmediata.
+
+Esa parte es importante porque el ahorro se compone:
+
+```text
+menos salida de búsqueda
++ menos lecturas posteriores
++ menos llamadas a herramientas
++ más contexto libre para razonar
+```
+
+Medido como sesión completa de diez consultas, el patrón fue este:
+
+| Flujo | Coste estimado de sesión |
+| --- | ---: |
+| grep + lecturas | ~85.800 tokens |
+| glob + lecturas | ~36.960 tokens |
+| Vectos + lecturas puntuales | ~11.390 tokens |
+
+Ese `~87%` de reducción frente a un flujo basado en `grep` no viene de una sola optimización. Viene de evitar trabajo que el agente no debería tener que hacer.
+
+---
+
+## Documentación: otro sitio donde se nota
+
+La búsqueda en documentación tiene un problema parecido.
+
+Los archivos Markdown suelen ser largos, mezclan guías, referencias, decisiones y ejemplos, y una búsqueda textual puede encontrar demasiadas coincidencias sin apuntar a la sección correcta.
+
+Por eso Vectos mantiene un índice separado para docs:
+
+```bash
+vectos index . --docs
+vectos search --docs "how to run tests"
+```
+
+En las mediciones sobre documentación bilingüe, las consultas conceptuales también mostraron diferencias grandes:
+
+| Intención | Vectos | grep |
+| --- | ---: | ---: |
+| Testing strategy | ~115 tokens | ~6.418 tokens |
+| Internationalization | ~120 tokens | ~5.419 tokens |
+| Component architecture | ~120 tokens | ~3.039 tokens |
+| Development setup | ~113 tokens | ~1.050 tokens |
+| Recaptcha security | ~130 tokens | ~450 tokens |
+
+El caso `recaptcha` es interesante porque muestra el límite: cuando el término es muy específico, `grep` ya va bastante bien. Vectos sigue devolviendo menos ruido, pero la diferencia deja de ser espectacular.
+
+Eso me parece sano. La herramienta no tiene que ganar siempre. Tiene que ganar donde el flujo real duele.
+
+---
+
+## Rendimiento: no solo tokens
+
+También hay una parte de rendimiento puro.
+
+Pasar de una búsqueda vectorial lineal a `HNSW` cambia el margen de crecimiento del índice. En proyectos pequeños quizá no se nota demasiado, pero es una decisión necesaria si quiero que Vectos sea útil en repos medianos o monorepos.
+
+El payload MCP también importa. Un agente no consume una tabla idealizada; consume una respuesta real de herramienta. En una comprobación representativa dentro del propio repo de Vectos, un payload de `3` resultados medía alrededor de `1242 bytes`; con `5` resultados, `1966 bytes`; con `10`, `3818 bytes`.
+
+La conclusión práctica es simple: el número de resultados escala casi linealmente. Mantener una ventana por defecto de `5` resultados es un buen equilibrio entre cobertura y coste.
+
+Más resultados no siempre significan mejor contexto. A veces solo significan más decisiones pendientes para el agente.
+
+---
+
+## Dónde no usaría Vectos
+
+Cuanto más lo uso, más claro tengo que Vectos no debe intentar reemplazar todas las herramientas.
+
+Usaría `grep` para:
+
+- strings exactos
+- imports concretos
+- IDs únicos
+- códigos de error
+- patrones regex
+
+Usaría `glob` para:
+
+- descubrir archivos por nombre
+- listar `*.spec.ts`
+- encontrar convenciones de carpetas
+
+Usaría `ast-grep` para:
+
+- refactors estructurales
+- buscar usos de una API concreta
+- localizar patrones de AST repetidos
+
+Usaría `Vectos` cuando la pregunta sea más parecida a:
+
+- “dónde se implementa este flujo”
+- “qué controla esta experiencia”
+- “cómo se conecta esta feature”
+- “qué docs explican esta decisión”
+- “dónde debería empezar a leer”
+
+Esa frontera me interesa porque evita convertir Vectos en una herramienta genérica sin foco. Su valor está en orientar, no en sustituir cada primitive del sistema.
+
+---
+
+## Lo que esto cambia en mi forma de trabajar
+
+La mejora más clara no es que cada búsqueda sea perfecta.
+
+La mejora es que el agente empieza mejor.
+
+Y cuando un agente empieza mejor:
+
+- lee menos basura
+- usa menos contexto
+- hace menos llamadas de exploración
+- llega antes al archivo correcto
+- deja más tokens para razonar, editar y verificar
+
+Esa es la razón por la que sigo invirtiendo en Vectos.
+
+No porque los embeddings sean interesantes por sí mismos. Sino porque una parte enorme del trabajo con agentes consiste en transformar una intención humana en un punto correcto del código.
+
+Si esa traducción mejora, todo el flujo mejora.
+
+---
+
+## Siguiente foco
+
+Después de estas mediciones, las prioridades quedan más claras:
+
+- mejorar todavía más la calidad del ranking híbrido
+- afinar previews para que respondan más sin obligar a leer archivos
+- mantener payloads pequeños en MCP
+- hacer que el reindexado incremental sea cada vez más invisible
+- seguir validando contra repos reales, no solo fixtures cómodas
+
+Vectos sigue siendo experimental, pero ya no lo veo solo como una intuición prometedora. Ahora tengo mejores datos para explicar por qué esta capa tiene sentido.
+
+Los agentes no necesitan más contexto por defecto.
+
+Necesitan mejor orientación antes de gastar contexto.
+
+_Relacionado:_
+
+- [Vectos: qué es, cómo funciona y por qué lo estoy construyendo](/es/blog/2026-04-25-vectos-semantic-code-retrieval-agents)
+- [Por qué la memoria no basta para trabajar con agentes sobre código real](/es/blog/2026-04-24-unified-memory-code-embeddings-local)

--- a/src/content/projects/en/vectos.md
+++ b/src/content/projects/en/vectos.md
@@ -14,6 +14,7 @@ outcomes:
   - 'Incremental reindexing for fast feedback during active development'
 repoName: vectos
 relatedPosts:
+  - 'vectos-performance-token-efficiency-agents'
   - 'vectos-semantic-code-retrieval-agents'
   - 'unified-memory-code-embeddings-local'
 ---

--- a/src/content/projects/es/vectos.md
+++ b/src/content/projects/es/vectos.md
@@ -14,6 +14,7 @@ outcomes:
   - 'Reindexado incremental para feedback rápido durante el desarrollo'
 repoName: vectos
 relatedPosts:
+  - 'vectos-performance-token-efficiency-agents'
   - 'vectos-semantic-code-retrieval-agents'
   - 'unified-memory-code-embeddings-local'
 ---

--- a/src/pages/Blog/components/BlogPost.tsx
+++ b/src/pages/Blog/components/BlogPost.tsx
@@ -1,6 +1,7 @@
+import type { ComponentPropsWithoutRef } from 'react'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { type ExtraProps } from 'react-markdown'
 import { useParams, Navigate, Link } from 'react-router'
 
 import { motion } from 'framer-motion'
@@ -11,10 +12,73 @@ import { BlogError } from './BlogError'
 import { BlogLoading } from './BlogLoading'
 
 import { DocumentHead } from '../../../components/DocumentHead'
+import {
+  MarkdownTable,
+  MarkdownTableCell,
+  MarkdownTableHead,
+  MarkdownTableHeader,
+} from '../../../components/MarkdownTable'
 import { useThemeContext } from '../../../context'
 import { useBlogPost } from '../../../hooks/useBlog'
 import { fadeIn, smoothTransition } from '../../../lib/animations'
 import { buildLocalizedSeoUrls } from '../../../lib/seo'
+
+type MdProps<T extends keyof React.JSX.IntrinsicElements> = Omit<
+  ComponentPropsWithoutRef<T> & ExtraProps,
+  'node'
+>
+
+const MarkdownH1 = ({ children }: MdProps<'h1'>) => (
+  <h1 className="mt-8 mb-6 text-3xl font-bold text-gray-900 dark:text-white">{children}</h1>
+)
+const MarkdownH2 = ({ children }: MdProps<'h2'>) => (
+  <h2 className="mt-6 mb-4 text-2xl font-semibold text-gray-900 dark:text-white">{children}</h2>
+)
+const MarkdownH3 = ({ children }: MdProps<'h3'>) => (
+  <h3 className="mt-5 mb-3 text-xl font-semibold text-gray-900 dark:text-white">{children}</h3>
+)
+const MarkdownP = ({ children }: MdProps<'p'>) => (
+  <p className="mb-4 leading-relaxed text-gray-700 dark:text-gray-300">{children}</p>
+)
+const MarkdownUl = ({ children }: MdProps<'ul'>) => (
+  <ul className="mb-4 list-disc pl-6 text-gray-700 dark:text-gray-300">{children}</ul>
+)
+const MarkdownOl = ({ children }: MdProps<'ol'>) => (
+  <ol className="mb-4 list-decimal pl-6 text-gray-700 dark:text-gray-300">{children}</ol>
+)
+const MarkdownLi = ({ children }: MdProps<'li'>) => <li className="mb-1">{children}</li>
+const MarkdownBlockquote = ({ children }: MdProps<'blockquote'>) => (
+  <blockquote className="my-4 border-l-4 border-primary/50 bg-primary/5 py-2 pr-4 pl-4 text-gray-700 italic dark:border-primary-light/50 dark:bg-primary/10 dark:text-gray-300">
+    {children}
+  </blockquote>
+)
+const MarkdownA = ({ children, href }: MdProps<'a'>) => (
+  <a
+    href={href}
+    className="text-primary underline decoration-primary/30 transition-colors hover:decoration-primary dark:text-primary-light dark:decoration-primary-light/30 dark:hover:decoration-primary-light"
+    target={href?.startsWith('http') ? '_blank' : undefined}
+    rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+  >
+    {children}
+  </a>
+)
+const MarkdownStrong = ({ children }: MdProps<'strong'>) => (
+  <strong className="font-semibold text-gray-900 dark:text-white">{children}</strong>
+)
+const MarkdownCode = ({ children, className }: MdProps<'code'>) => {
+  const isInline = !className
+
+  return isInline ? (
+    <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-200">
+      {children}
+    </code>
+  ) : (
+    <code className={className}>{children}</code>
+  )
+}
+const MarkdownPre = ({ children }: MdProps<'pre'>) => (
+  <pre className="my-4 overflow-x-auto rounded-xl bg-gray-50 p-4 dark:bg-gray-900">{children}</pre>
+)
 
 export function BlogPost() {
   const { slug } = useParams<{ slug: string }>()
@@ -43,13 +107,12 @@ export function BlogPost() {
     return <BlogLoading />
   }
 
+  const handleRetry = () => {
+    refetch().catch(() => undefined)
+  }
+
   if (error || !post) {
-    return (
-      <BlogError
-        message={error?.message ?? t('blog.postNotFound')}
-        onRetry={() => void refetch()}
-      />
-    )
+    return <BlogError message={error?.message ?? t('blog.postNotFound')} onRetry={handleRetry} />
   }
 
   const seoUrls = buildLocalizedSeoUrls(import.meta.env.VITE_SITE_URL, `/blog/${slug}`, locale)
@@ -160,72 +223,22 @@ export function BlogPost() {
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeHighlight]}
               components={{
-                h1: ({ children }) => (
-                  <h1 className="mt-8 mb-6 text-3xl font-bold text-gray-900 dark:text-white">
-                    {children}
-                  </h1>
-                ),
-                h2: ({ children }) => (
-                  <h2 className="mt-6 mb-4 text-2xl font-semibold text-gray-900 dark:text-white">
-                    {children}
-                  </h2>
-                ),
-                h3: ({ children }) => (
-                  <h3 className="mt-5 mb-3 text-xl font-semibold text-gray-900 dark:text-white">
-                    {children}
-                  </h3>
-                ),
-                p: ({ children }) => (
-                  <p className="mb-4 leading-relaxed text-gray-700 dark:text-gray-300">
-                    {children}
-                  </p>
-                ),
-                ul: ({ children }) => (
-                  <ul className="mb-4 list-disc pl-6 text-gray-700 dark:text-gray-300">
-                    {children}
-                  </ul>
-                ),
-                ol: ({ children }) => (
-                  <ol className="mb-4 list-decimal pl-6 text-gray-700 dark:text-gray-300">
-                    {children}
-                  </ol>
-                ),
-                li: ({ children }) => <li className="mb-1">{children}</li>,
-                blockquote: ({ children }) => (
-                  <blockquote className="my-4 border-l-4 border-primary/50 bg-primary/5 py-2 pr-4 pl-4 text-gray-700 italic dark:border-primary-light/50 dark:bg-primary/10 dark:text-gray-300">
-                    {children}
-                  </blockquote>
-                ),
-                a: ({ children, href }) => (
-                  <a
-                    href={href}
-                    className="text-primary underline decoration-primary/30 transition-colors hover:decoration-primary dark:text-primary-light dark:decoration-primary-light/30 dark:hover:decoration-primary-light"
-                    target={href?.startsWith('http') ? '_blank' : undefined}
-                    rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
-                  >
-                    {children}
-                  </a>
-                ),
-                strong: ({ children }) => (
-                  <strong className="font-semibold text-gray-900 dark:text-white">
-                    {children}
-                  </strong>
-                ),
-                code: ({ children, className }) => {
-                  const isInline = !className
-                  return isInline ? (
-                    <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm text-gray-800 dark:bg-gray-800 dark:text-gray-200">
-                      {children}
-                    </code>
-                  ) : (
-                    <code className={className}>{children}</code>
-                  )
-                },
-                pre: ({ children }) => (
-                  <pre className="my-4 overflow-x-auto rounded-xl bg-gray-50 p-4 dark:bg-gray-900">
-                    {children}
-                  </pre>
-                ),
+                h1: MarkdownH1,
+                h2: MarkdownH2,
+                h3: MarkdownH3,
+                p: MarkdownP,
+                ul: MarkdownUl,
+                ol: MarkdownOl,
+                li: MarkdownLi,
+                blockquote: MarkdownBlockquote,
+                a: MarkdownA,
+                strong: MarkdownStrong,
+                code: MarkdownCode,
+                pre: MarkdownPre,
+                table: MarkdownTable,
+                thead: MarkdownTableHead,
+                th: MarkdownTableHeader,
+                td: MarkdownTableCell,
               }}
             >
               {post.content}

--- a/src/pages/Projects/components/ProjectCaseStudy.tsx
+++ b/src/pages/Projects/components/ProjectCaseStudy.tsx
@@ -13,6 +13,12 @@ import { ProjectCaseStudyError } from './ProjectCaseStudyError'
 import { ProjectCaseStudyLoading } from './ProjectCaseStudyLoading'
 
 import { DocumentHead } from '../../../components/DocumentHead'
+import {
+  MarkdownTable,
+  MarkdownTableCell,
+  MarkdownTableHead,
+  MarkdownTableHeader,
+} from '../../../components/MarkdownTable'
 import { useThemeContext } from '../../../context'
 import { useProjectWithCaseStudy } from '../../../hooks/useProjectsWithCaseStudies'
 import { fadeIn, smoothTransition } from '../../../lib/animations'
@@ -70,7 +76,6 @@ const MarkdownPre = ({ children, ...props }: MdProps<'pre'>) => (
     {children}
   </pre>
 )
-
 export function ProjectCaseStudy() {
   const { slug } = useParams<{ slug: string }>()
   const { t, i18n } = useTranslation()
@@ -232,6 +237,10 @@ export function ProjectCaseStudy() {
               a: MarkdownA,
               code: MarkdownCode,
               pre: MarkdownPre,
+              table: MarkdownTable,
+              thead: MarkdownTableHead,
+              th: MarkdownTableHeader,
+              td: MarkdownTableCell,
             }}
           >
             {caseStudy.content}


### PR DESCRIPTION
## Summary
- Add bilingual Vectos performance/token-efficiency blog post
- Link the new post from the Vectos project pages
- Add responsive Markdown table rendering for blog posts and project case studies
- Refactor BlogPost Markdown renderers to avoid inline component/Sonar warnings

## Verification
- rtk lint
- pnpm type-check
- pnpm build