### PR TITLE
docs: sync docs/ with codebase + drop dead axios chunk-group entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ pnpm preview
 
 ### Core Technologies
 
-- **React 19.0** - UI library
-- **TypeScript 5.6** - Type safety
-- **Vite 6.0** - Build tool and dev server
-- **Tailwind CSS 4.0** - Utility-first CSS framework
+- **React 19.2** - UI library
+- **TypeScript 5.9** - Type safety
+- **Vite 8.0** - Build tool and dev server
+- **Tailwind CSS 4.2** - Utility-first CSS framework
 
 ### Key Libraries
 
@@ -85,8 +85,7 @@ pnpm preview
 - **React Hook Form** - Form management
 - **React Query (TanStack)** - Server state management
 - **React i18next** - Internationalization
-- **Zustand** - Global state management
-- **Axios** - HTTP client
+- **Zod** - Schema validation
 
 ### Development Tools
 
@@ -110,11 +109,18 @@ mywebsite-2/
 ├── src/
 │   ├── components/        # Reusable UI components
 │   ├── pages/            # Page components
+│   ├── content/          # Blog markdown content
+│   ├── context/          # React context providers
+│   ├── data/             # Static data sources
 │   ├── hooks/            # Custom React hooks
+│   ├── i18n/             # Internationalization configuration
 │   ├── lib/              # Utility libraries
 │   ├── locales/          # Translation files
 │   ├── router/           # Routing configuration
-│   └── styles/           # Global styles
+│   ├── styles/           # Global styles
+│   ├── utils/            # General utilities
+│   ├── types/            # Shared TypeScript types
+│   └── types.ts          # Global TypeScript types
 └── ...config files
 ```
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -89,12 +89,12 @@ pages/
 #### Core Framework
 
 - **React 19.0**: Latest React with concurrent features
-- **TypeScript 5.6**: Full type safety and enhanced DX
-- **Vite 6.0**: Modern build tool with HMR
+- **TypeScript 5.9**: Full type safety and enhanced DX
+- **Vite 8.0**: Modern build tool with HMR
 
 #### Routing
 
-- **React Router 7.2**: Client-side routing with nested routes
+- **React Router 7.17**: Client-side routing with nested routes
 - **Route-based code splitting**: Automatic bundle optimization
 - **Language-aware routing**: URL structure supports i18n
 
@@ -107,7 +107,7 @@ pages/
 
 #### Styling Architecture
 
-- **Tailwind CSS 4.0**: Utility-first CSS framework
+- **Tailwind CSS 4.2**: Utility-first CSS framework
 - **CSS Custom Properties**: Dynamic theming support
 - **Component-scoped styles**: Modular CSS approach
 - **Responsive design**: Mobile-first breakpoints
@@ -127,7 +127,7 @@ Custom Hooks (useProjects, useAboutData)
      ↓
 React Query (Server State Management)
      ↓
-HTTP Client (Axios)
+HTTP Client (native fetch)
      ↓
 External APIs (GitHub, Email Service)
 ```
@@ -161,14 +161,22 @@ src/
 ├── hooks/                  # Custom React hooks
 ├── lib/                    # Utility libraries
 │   ├── animations.ts       # Animation configurations
-│   ├── axios.ts           # HTTP client setup
-│   └── queryClient.ts     # React Query setup
+│   ├── clientObservability.ts # Client-side observability/logging
+│   ├── queryClient.ts     # React Query setup
+│   ├── security.ts        # Security utilities
+│   └── seo.ts             # SEO helpers
 ├── locales/               # Translation files
 │   ├── en/                # English translations
 │   └── es/                # Spanish translations
 ├── router/                # Routing configuration
 │   ├── index.tsx          # Router setup
 │   └── routes.tsx         # Route definitions
+├── i18n/                  # Internationalization config
+├── content/               # Static content/data
+├── context/               # React Context providers
+├── data/                  # Data sources and repositories
+├── utils/                 # Utility helpers
+├── types/                 # Shared TypeScript type definitions
 ├── constants/             # Application constants
 ├── styles/               # Global styles
 ├── types.ts              # Global TypeScript types
@@ -331,7 +339,7 @@ export const smoothTransition = {
 1. **Code Splitting**: Route-based lazy loading
 2. **Tree Shaking**: Unused code elimination
 3. **Asset Optimization**: Image compression and lazy loading
-4. **Bundle Analysis**: Webpack bundle analyzer integration
+4. **Bundle Analysis**: Vite + rollup-plugin-visualizer (`pnpm build:analyze`)
 
 ### Runtime Performance
 
@@ -372,7 +380,6 @@ const ProjectsPage = lazy(() => import('./pages/Projects'))
 
 - **Vitest**: Fast unit test runner
 - **React Testing Library**: Component testing utilities
-- **MSW**: API mocking for tests
 - **Playwright**: E2E testing framework
 
 ## 🚀 Deployment Architecture

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -88,7 +88,7 @@ pages/
 
 #### Core Framework
 
-- **React 19.0**: Latest React with concurrent features
+- **React 19.2**: Latest React with concurrent features
 - **TypeScript 5.9**: Full type safety and enhanced DX
 - **Vite 8.0**: Modern build tool with HMR
 

--- a/docs/en/COMPONENTS.md
+++ b/docs/en/COMPONENTS.md
@@ -15,10 +15,19 @@ The component library follows atomic design principles and is organized into dif
 
 ```text
 src/components/
-├── Layout.tsx              # Main layout wrapper
-├── Navbar.tsx              # Navigation component
+├── DocumentHead.tsx        # SEO head tags (title, meta, OG) per route
 ├── Footer.tsx              # Footer component
 ├── LanguageSwitcher.tsx    # Language toggle
+├── Layout.tsx              # Main layout wrapper
+├── MarkdownTable.tsx       # Styled wrapper for markdown tables
+├── Navbar.tsx              # Navigation component
+├── NavigationProgress.tsx  # Top loading bar on route changes
+├── OptimizedImage.tsx      # Responsive images + SVG logos, lazy/error states
+├── ParticlesBackground.tsx # Animated particle background canvas
+├── RoutePreloader.tsx     # Preloads route chunks on link hover
+├── ScrollToTop.tsx         # Resets scroll position on navigation
+├── SkipLinks.tsx           # Accessibility skip-to-content links
+├── ThemeToggle.tsx         # Light/dark theme switch
 └── index.ts                # Component exports
 
 src/pages/
@@ -39,12 +48,17 @@ src/pages/
 │   │   ├── AboutContent.tsx
 │   │   ├── TechnologyGrid.tsx
 │   │   └── index.ts
-└── Contact/
-    ├── components/
-    │   ├── ContactForm.tsx
-    │   ├── ContactHeader.tsx
-    │   └── index.ts
+├── Blog/
+│   └── components/
+├── Contact/
+│   ├── components/
+│   │   ├── ContactForm.tsx
+│   │   ├── ContactHeader.tsx
+│   │   └── index.ts
+└── NotFound.tsx
 ```
+
+> Note: `OptimizedImage` replaced the former `OptimizedLogo` component, which no longer exists. SVG logos and raster images are both handled by `OptimizedImage`.
 
 ## 🏗️ Layout Components
 
@@ -165,6 +179,20 @@ const LanguageSwitcher: React.FC = () => {
 - Smooth language switching
 - URL update with new language
 - Persistent language preference
+
+## 🧩 Shared Utility Components
+
+Beyond the layout components above, `src/components/` exports several shared utilities used across pages:
+
+- **`OptimizedImage`** (`OptimizedImage.tsx`): Handles responsive raster images and SVG logos with lazy loading and error fallback states. It replaced the former `OptimizedLogo` component, which no longer exists.
+- **`ThemeToggle`** (`ThemeToggle.tsx`): Light/dark theme switch wired to the theme provider.
+- **`SkipLinks`** (`SkipLinks.tsx`): Accessibility skip-to-content links for keyboard users.
+- **`ScrollToTop`** (`ScrollToTop.tsx`): Resets scroll position to the top on route changes.
+- **`NavigationProgress`** (`NavigationProgress.tsx`): Top loading bar shown during route transitions.
+- **`ParticlesBackground`** (`ParticlesBackground.tsx`): Animated particle canvas used as a decorative background.
+- **`DocumentHead`** (`DocumentHead.tsx`): Manages SEO head tags (title, meta, Open Graph) per route.
+- **`MarkdownTable`** (`MarkdownTable.tsx`): Styled wrapper for rendering markdown tables.
+- **`RoutePreloader`** (`RoutePreloader.tsx`): Preloads route chunks on link hover to speed up navigation.
 
 ## 🏠 Home Page Components
 

--- a/docs/en/DEVELOPMENT.md
+++ b/docs/en/DEVELOPMENT.md
@@ -8,8 +8,8 @@ This guide provides comprehensive information for developers working on the Migu
 
 Before starting development, ensure you have the following installed:
 
-- **Node.js**: v18.0.0 or higher
-- **pnpm**: v8.0.0 or higher (recommended package manager)
+- **Node.js**: v20 or higher
+- **pnpm**: v10+ (project pins pnpm 11.x via `packageManager`)
 - **Git**: v2.30.0 or higher
 - **VS Code**: Recommended IDE with extensions
 
@@ -128,27 +128,33 @@ style(navbar): improve responsive design
 
 ```bash
 # Development
-pnpm dev                 # Start development server with HMR
-pnpm dev:host           # Start dev server accessible on network
+pnpm dev                 # Start development server with HMR (vite --host)
 pnpm build              # Build for production
+pnpm build:analyze      # Build and analyze bundle size
 pnpm preview            # Preview production build locally
 
 # Code Quality
 pnpm lint               # Run ESLint
-pnpm lint:fix           # Fix ESLint issues automatically
 pnpm format             # Format code with Prettier
 pnpm format:check       # Check code formatting
+pnpm docs:lint          # Lint documentation files
+pnpm docs:lint:fix      # Auto-fix documentation lint issues
 pnpm type-check         # TypeScript type checking
+pnpm quality            # lint + docs:lint + format:check + type-check
 
 # Testing
 pnpm test               # Run test suite
 pnpm test:watch         # Run tests in watch mode
 pnpm test:coverage      # Run tests with coverage report
 pnpm test:ui            # Open Vitest UI
+pnpm test:coverage:ui   # Coverage report with Vitest UI
+pnpm test:e2e           # Run Playwright end-to-end tests
 
 # Git Hooks
 pnpm prepare            # Setup Husky git hooks
 ```
+
+> Note: there is no `lint:fix` script. ESLint auto-fix runs through lint-staged on staged files (`eslint . --fix`), or run it directly: `pnpm exec eslint . --fix`.
 
 ## 📋 Coding Standards
 
@@ -547,8 +553,7 @@ module.exports = {
 1. **Analyze bundle size**
 
    ```bash
-   pnpm build
-   pnpm run analyze  # If bundle analyzer is configured
+   pnpm build:analyze  # Build for production and analyze bundle size
    ```
 
 2. **Import only what you need**

--- a/docs/en/I18N.md
+++ b/docs/en/I18N.md
@@ -41,35 +41,33 @@ src/
 **File**: `src/i18n/i18n.ts`
 
 ```typescript
-import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 
 // Import translation files
-import enTranslations from '../locales/en/translation.json'
-import esTranslations from '../locales/es/translation.json'
+import translationEN from '../locales/en/translation.json'
+import translationES from '../locales/es/translation.json'
 
-i18n
+void i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: {
       en: {
-        translation: enTranslations,
+        translation: translationEN,
       },
       es: {
-        translation: esTranslations,
+        translation: translationES,
       },
     },
-    fallbackLng: 'en',
-    debug: import.meta.env.DEV,
+    fallbackLng: 'es',
+    supportedLngs: ['es', 'en'],
     interpolation: {
       escapeValue: false, // React already escapes values
     },
     detection: {
-      order: ['path', 'localStorage', 'navigator'],
-      lookupFromPathIndex: 0,
-      checkWhitelist: true,
+      order: ['path', 'navigator'],
     },
   })
 
@@ -78,8 +76,8 @@ export default i18n
 
 ### Configuration Options
 
-- **fallbackLng**: Default language when detection fails
-- **debug**: Enable debug mode in development
+- **fallbackLng**: Default language when detection fails (`'es'`)
+- **supportedLngs**: Languages the app supports (`['es', 'en']`)
 - **detection**: Language detection strategy
 - **interpolation**: Variable interpolation settings
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -32,7 +32,7 @@ This is a modern, multilingual personal portfolio website built with cutting-edg
 
 #### Core Technologies
 
-- **React 19.0** - Modern UI library with latest features
+- **React 19.2** - Modern UI library with latest features
 - **TypeScript 5.9** - Type safety and enhanced developer experience
 - **Vite 8.0** - Fast build tool and development server
 - **Tailwind CSS 4.2** - Utility-first CSS framework
@@ -93,9 +93,9 @@ mywebsite-2/
 │   ├── styles/           # Global styles
 │   ├── utils/            # General utilities
 │   ├── constants/        # Application constants
-│   └── types/            # TypeScript type definitions
+│   ├── types/            # Shared TypeScript type definitions
+│   └── types.ts          # Global TypeScript types
 ├── .github/              # GitHub workflows and templates
-├── tests/                # Test utilities and configuration
 └── configuration files   # Various config files
 ```
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -33,18 +33,18 @@ This is a modern, multilingual personal portfolio website built with cutting-edg
 #### Core Technologies
 
 - **React 19.0** - Modern UI library with latest features
-- **TypeScript 5.6** - Type safety and enhanced developer experience
-- **Vite 6.0** - Fast build tool and development server
-- **Tailwind CSS 4.0** - Utility-first CSS framework
+- **TypeScript 5.9** - Type safety and enhanced developer experience
+- **Vite 8.0** - Fast build tool and development server
+- **Tailwind CSS 4.2** - Utility-first CSS framework
 
 #### Key Libraries
 
-- **Framer Motion 12.4** - Animation library for smooth transitions
-- **React Router 7.2** - Client-side routing
-- **React Hook Form 7.60** - Form management with validation
-- **TanStack Query 5.67** - Server state management
-- **React i18next 15.4** - Internationalization framework
-- **Axios 1.8** - HTTP client for API requests
+- **Framer Motion 12.38** - Animation library for smooth transitions
+- **React Router 7.17** - Client-side routing
+- **React Hook Form 7.72** - Form management with validation
+- **TanStack Query 5.95** - Server state management
+- **React i18next 15.7** - Internationalization framework
+- **Zod 4.3** - Schema validation
 
 #### Development Tools
 
@@ -67,29 +67,33 @@ mywebsite-2/
 │   ├── logo.svg           # Main logo
 │   └── logo_*.svg         # Logo variations
 ├── src/
-│   ├── components/        # Reusable UI components
-│   │   ├── Footer.tsx
-│   │   ├── Layout.tsx
-│   │   ├── LanguageSwitcher.tsx
-│   │   └── Navbar.tsx
+│   ├── components/        # Reusable UI components (Footer, Layout, Navbar, LanguageSwitcher, ...)
 │   ├── pages/            # Page components
 │   │   ├── Home/         # Home page components
 │   │   ├── About/        # About page components
 │   │   ├── Projects/     # Projects page components
 │   │   ├── Contact/      # Contact page components
+│   │   ├── Blog/         # Blog page components
 │   │   └── NotFound.tsx  # 404 page
+│   ├── content/          # Blog markdown content
+│   ├── context/          # React context providers
+│   ├── data/             # Static data sources
 │   ├── hooks/            # Custom React hooks
+│   ├── i18n/             # Internationalization configuration
 │   ├── lib/              # Utility libraries
-│   │   ├── animations.ts # Animation configurations
-│   │   ├── axios.ts      # HTTP client setup
-│   │   └── queryClient.ts # React Query configuration
+│   │   ├── animations.ts    # Animation configurations
+│   │   ├── queryClient.ts   # React Query configuration
+│   │   ├── security.ts      # Security helpers
+│   │   ├── seo.ts           # SEO utilities
+│   │   └── clientObservability.ts # Client-side observability
 │   ├── locales/          # Translation files
 │   │   ├── en/           # English translations
 │   │   └── es/           # Spanish translations
 │   ├── router/           # Routing configuration
 │   ├── styles/           # Global styles
+│   ├── utils/            # General utilities
 │   ├── constants/        # Application constants
-│   └── types.ts          # TypeScript type definitions
+│   └── types/            # TypeScript type definitions
 ├── .github/              # GitHub workflows and templates
 ├── tests/                # Test utilities and configuration
 └── configuration files   # Various config files
@@ -126,6 +130,12 @@ mywebsite-2/
 - reCAPTCHA integration for spam protection
 - Success and error state handling
 - Social media links
+
+### Blog Page (`/blog`)
+
+- Markdown-driven blog posts
+- Post listing and individual post views
+- Multilingual content support
 
 ## 🔧 Quick Start
 

--- a/docs/en/TESTING.md
+++ b/docs/en/TESTING.md
@@ -22,46 +22,51 @@ The project follows a comprehensive testing approach with multiple levels:
 
 ### Additional Testing Tools
 
-- **MSW (Mock Service Worker)**: API mocking for realistic testing
 - **@testing-library/user-event**: User interaction simulation
-- **Playwright**: End-to-end testing framework (future implementation)
+- **Playwright**: End-to-end testing framework. E2E tests run via Playwright; `pnpm test:e2e`
 
 ## ⚙️ Configuration
 
 ### Vitest Configuration
 
-**File**: `vitest.config.ts`
+**File**: `vite.config.ts` (the `test` block)
 
 ```typescript
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import path from 'path'
+import { configDefaults } from 'vitest/config'
+// ...vite plugins, resolve.alias, build...
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(() => ({
+  // ...plugins, resolve, build...
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    css: true,
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'e2e/*'],
     coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      provider: 'v8' as const,
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
-        '**/coverage/**',
+        ...(configDefaults.coverage.exclude ?? []),
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**',
+        'src/**/*.d.ts',
+        'src/types/**',
+        'src/vite-env.d.ts',
+        'src/main.tsx',
+        'src/i18n/**',
+        'src/constants/**',
       ],
+      thresholds: {
+        lines: 20,
+        functions: 15,
+        branches: 15,
+        statements: 20,
+      },
     },
   },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-})
+}))
 ```
 
 ### Test Setup
@@ -69,33 +74,17 @@ export default defineConfig({
 **File**: `src/test/setup.ts`
 
 ```typescript
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeAll, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
-import { afterEach, vi } from 'vitest'
 
-// Cleanup after each test
-afterEach(() => {
-  cleanup()
-})
+// Import and configure i18n for tests
+import './i18n-for-tests'
 
-// Mock IntersectionObserver
-global.IntersectionObserver = vi.fn(() => ({
-  disconnect: vi.fn(),
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-}))
-
-// Mock ResizeObserver
-global.ResizeObserver = vi.fn(() => ({
-  disconnect: vi.fn(),
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-}))
-
-// Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
+// Mock window.matchMedia for components using useReducedMotion
+Object.defineProperty(globalThis, 'matchMedia', {
   writable: true,
-  value: vi.fn().mockImplementation(query => ({
+  value: vi.fn().mockImplementation((query: string) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -105,6 +94,40 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   })),
+})
+
+// Mock IntersectionObserver for framer-motion whileInView in jsdom
+class MockIntersectionObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds: number[] = []
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  writable: true,
+  value: MockIntersectionObserver,
+})
+
+// Suppress specific known console errors in tests
+const originalError = console.error
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    const firstArg = args[0]
+    const message =
+      firstArg instanceof Error ? firstArg.message : typeof firstArg === 'string' ? firstArg : JSON.stringify(firstArg)
+    if (message.includes('Error sending message') || message.includes('Validation error')) return
+    originalError(...args)
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
 })
 ```
 
@@ -140,9 +163,7 @@ src/
 └── test/
     ├── setup.ts
     ├── utils.tsx
-    └── mocks/
-        ├── handlers.ts
-        └── server.ts
+    └── i18n-for-tests.ts
 ```
 
 ### Naming Conventions
@@ -341,53 +362,72 @@ describe('Project Utils', () => {
 
 ## 🎭 Mocking Strategies
 
-### API Mocking with MSW
+### API Mocking by Stubbing `fetch`
 
-**File**: `src/test/mocks/handlers.ts`
-
-```typescript
-import { rest } from 'msw'
-
-export const handlers = [
-  // Mock GitHub API
-  rest.get('https://api.github.com/users/:username/repos', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          id: 1,
-          name: 'mock-project',
-          description: 'Mock project description',
-          html_url: 'https://github.com/user/mock-project',
-          stargazers_count: 42,
-          forks_count: 8,
-          language: 'TypeScript',
-          topics: ['react', 'typescript'],
-          updated_at: '2023-12-01T00:00:00Z',
-          homepage: 'https://mock-project.com',
-        },
-      ])
-    )
-  }),
-  
-  // Mock contact form submission
-  rest.post('/api/contact', (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({ success: true, message: 'Message sent successfully' })
-    )
-  }),
-]
-```
-
-**File**: `src/test/mocks/server.ts`
+The project does not use MSW. API calls are mocked by stubbing the global `fetch` with `vi.fn()` / `vi.stubGlobal('fetch', ...)` and by mocking modules with `vi.mock(...)`.
 
 ```typescript
-import { setupServer } from 'msw/node'
-import { handlers } from './handlers'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
-export const server = setupServer(...handlers)
+import { useProjects } from './useProjects'
+
+describe('useProjects', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches projects successfully', async () => {
+    const mockProjects = [
+      {
+        id: 1,
+        name: 'mock-project',
+        description: 'Mock project description',
+        html_url: 'https://github.com/user/mock-project',
+        stargazers_count: 42,
+        forks_count: 8,
+        language: 'TypeScript',
+        topics: ['react', 'typescript'],
+        updated_at: '2023-12-01T00:00:00Z',
+        homepage: 'https://mock-project.com',
+      },
+    ]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockProjects),
+      } as Response),
+    )
+
+    render(<ProjectsList />)
+
+    await waitFor(() => {
+      expect(screen.getByText('mock-project')).toBeInTheDocument()
+    })
+  })
+
+  it('handles API errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ message: 'Server error' }),
+      } as Response),
+    )
+
+    render(<ProjectsList />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/error loading projects/i)).toBeInTheDocument()
+    })
+  })
+})
 ```
+
+For per-test overrides, re-stub `fetch` inside the test or use `vi.mocked(fetch).mockResolvedValueOnce(...)`.
 
 ### Component Mocking
 
@@ -419,35 +459,37 @@ vi.mock('react-router', () => ({
 ### Coverage Configuration
 
 ```typescript
-// vitest.config.ts
-export default defineConfig({
+// vite.config.ts (the `test` block)
+export default defineConfig(() => ({
   test: {
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
-        '**/coverage/**',
-        'src/main.tsx',
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**',
+        'src/**/*.d.ts',
+        'src/types/**',
         'src/vite-env.d.ts',
+        'src/main.tsx',
+        'src/i18n/**',
+        'src/constants/**',
       ],
+      thresholds: {
+        lines: 20,
+        functions: 15,
+        branches: 15,
+        statements: 20,
+      },
     },
   },
-})
+}))
 ```
 
 ### Coverage Goals
+
+The thresholds enforced by the configuration above are intentionally low (lines/statements 20%, functions/branches 15%) to keep CI green while coverage grows. The following are aspirational targets, not enforced gates:
 
 - **Components**: 90%+ coverage
 - **Utils**: 95%+ coverage
@@ -482,15 +524,18 @@ export default defineConfig({
 
    ```typescript
    it('displays error message when API fails', async () => {
-     // Mock API to fail
-     server.use(
-       rest.get('/api/projects', (req, res, ctx) => {
-         return res(ctx.status(500))
-       })
+     // Stub fetch to fail
+     vi.stubGlobal(
+       'fetch',
+       vi.fn().mockResolvedValue({
+         ok: false,
+         status: 500,
+         json: () => Promise.resolve({ message: 'Server error' }),
+       } as Response),
      )
-     
+
      render(<ProjectsList />)
-     
+
      await waitFor(() => {
        expect(screen.getByText(/error loading projects/i)).toBeInTheDocument()
      })
@@ -546,7 +591,8 @@ describe('ProjectCard Component', () => {
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
-    "test:ci": "vitest run --coverage --reporter=verbose"
+    "test:coverage:ui": "vitest --ui --coverage",
+    "test:e2e": "playwright test"
   }
 }
 ```
@@ -565,6 +611,9 @@ pnpm test:coverage
 
 # Open Vitest UI
 pnpm test:ui
+
+# Run E2E tests with Playwright
+pnpm test:e2e
 
 # Run specific test file
 pnpm test ProjectCard.test.tsx
@@ -598,9 +647,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       
-      - name: Run tests
-        run: pnpm test:ci
-      
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3
         with:
@@ -653,7 +705,7 @@ jobs:
 - [Vitest Documentation](https://vitest.dev/)
 - [React Testing Library Documentation](https://testing-library.com/docs/react-testing-library/intro/)
 - [Testing Library Best Practices](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
-- [MSW Documentation](https://mswjs.io/)
+- [Playwright Documentation](https://playwright.dev/)
 - [Jest DOM Matchers](https://github.com/testing-library/jest-dom)
 
 ---

--- a/docs/en/TESTING.md
+++ b/docs/en/TESTING.md
@@ -627,36 +627,66 @@ pnpm test --grep="renders correctly"
 ### GitHub Actions Configuration
 
 ```yaml
-name: Tests
+name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  test:
+  quality:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
-      
+          node-version: 22
+          cache: pnpm
+
       - name: Install dependencies
-        run: pnpm install
-      
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Lint
+        run: pnpm lint
+
       - name: Run tests with coverage
         run: pnpm test:coverage
 
+      - name: Build
+        run: pnpm build
+
+  e2e:
+    needs: quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm playwright install --with-deps chromium
+
       - name: Run E2E tests
         run: pnpm test:e2e
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 ```
 
 ## 🐛 Debugging Tests

--- a/docs/es/ARCHITECTURE.md
+++ b/docs/es/ARCHITECTURE.md
@@ -86,12 +86,12 @@ pages/
 #### Framework Principal
 
 - **React 19.0**: Última versión de React con características concurrentes
-- **TypeScript 5.6**: Seguridad de tipos completa y DX mejorada
-- **Vite 6.0**: Herramienta de build moderna con HMR
+- **TypeScript 5.9**: Seguridad de tipos completa y DX mejorada
+- **Vite 8.0**: Herramienta de build moderna con HMR
 
 #### Enrutamiento
 
-- **React Router 7.2**: Enrutamiento del lado del cliente con rutas anidadas
+- **React Router 7.17**: Enrutamiento del lado del cliente con rutas anidadas
 - **Code splitting basado en rutas**: Optimización automática de bundles
 - **Enrutamiento consciente del idioma**: Estructura URL soporta i18n
 
@@ -104,7 +104,7 @@ pages/
 
 #### Arquitectura de Estilos
 
-- **Tailwind CSS 4.0**: Framework CSS utility-first
+- **Tailwind CSS 4.2**: Framework CSS utility-first
 - **Propiedades CSS Personalizadas**: Soporte para temas dinámicos
 - **Estilos con alcance de componente**: Enfoque CSS modular
 - **Diseño responsivo**: Breakpoints mobile-first
@@ -124,7 +124,7 @@ Hooks Personalizados (useProjects, useAboutData)
      ↓
 React Query (Gestión de Estado del Servidor)
      ↓
-Cliente HTTP (Axios)
+Cliente HTTP (fetch nativo)
      ↓
 APIs Externas (GitHub, Servicio Email)
 ```
@@ -158,14 +158,22 @@ src/
 ├── hooks/                  # Hooks personalizados de React
 ├── lib/                    # Bibliotecas de utilidades
 │   ├── animations.ts       # Configuraciones de animación
-│   ├── axios.ts           # Configuración cliente HTTP
-│   └── queryClient.ts     # Configuración React Query
+│   ├── clientObservability.ts # Observabilidad/logging del cliente
+│   ├── queryClient.ts     # Configuración React Query
+│   ├── security.ts        # Utilidades de seguridad
+│   └── seo.ts             # Helpers SEO
 ├── locales/               # Archivos de traducción
 │   ├── en/                # Traducciones inglés
 │   └── es/                # Traducciones español
 ├── router/                # Configuración de enrutamiento
 │   ├── index.tsx          # Configuración router
 │   └── routes.tsx         # Definiciones de rutas
+├── i18n/                  # Configuración de internacionalización
+├── content/               # Contenido/datos estáticos
+├── context/               # Proveedores de React Context
+├── data/                  # Fuentes de datos y repositorios
+├── utils/                 # Helpers de utilidades
+├── types/                 # Definiciones de tipos TypeScript compartidos
 ├── constants/             # Constantes de aplicación
 ├── styles/               # Estilos globales
 ├── types.ts              # Tipos TypeScript globales
@@ -328,7 +336,7 @@ export const smoothTransition = {
 1. **Code Splitting**: Carga lazy basada en rutas
 2. **Tree Shaking**: Eliminación de código no usado
 3. **Optimización de Assets**: Compresión de imágenes y carga lazy
-4. **Análisis de Bundle**: Integración analizador bundle Webpack
+4. **Análisis de Bundle**: Vite + rollup-plugin-visualizer (`pnpm build:analyze`)
 
 ### Rendimiento en Tiempo de Ejecución
 
@@ -369,7 +377,6 @@ const ProjectsPage = lazy(() => import('./pages/Projects'))
 
 - **Vitest**: Ejecutor de pruebas unitarias rápido
 - **React Testing Library**: Utilidades de pruebas de componentes
-- **MSW**: Mocking de API para pruebas
 - **Playwright**: Framework de pruebas E2E
 
 ## 🚀 Arquitectura de Despliegue

--- a/docs/es/ARCHITECTURE.md
+++ b/docs/es/ARCHITECTURE.md
@@ -85,7 +85,7 @@ pages/
 
 #### Framework Principal
 
-- **React 19.0**: Última versión de React con características concurrentes
+- **React 19.2**: Última versión de React con características concurrentes
 - **TypeScript 5.9**: Seguridad de tipos completa y DX mejorada
 - **Vite 8.0**: Herramienta de build moderna con HMR
 

--- a/docs/es/COMPONENTS.md
+++ b/docs/es/COMPONENTS.md
@@ -7,24 +7,32 @@ Esta guía proporciona documentación completa de todos los componentes UI utili
 ### Organización Jerárquica
 
 ```text
-components/
-├── Layout/               # Componentes de layout
-│   ├── Layout.tsx       # Wrapper principal de aplicación
-│   ├── Navbar.tsx       # Barra de navegación
-│   └── Footer.tsx       # Pie de página
-├── UI/                  # Componentes UI básicos
-│   ├── Button.tsx       # Componente botón reutilizable
-│   ├── Input.tsx        # Componente input de formulario
-│   └── Modal.tsx        # Componente modal/dialog
-├── Features/            # Componentes específicos de funcionalidad
-│   ├── ProjectCard.tsx  # Tarjeta de proyecto
-│   ├── ContactForm.tsx  # Formulario de contacto
-│   └── TechGrid.tsx     # Grid de tecnologías
-└── Common/              # Componentes comunes
-    ├── LoadingSpinner.tsx
-    ├── ErrorBoundary.tsx
-    └── LanguageSwitcher.tsx
+src/components/
+├── DocumentHead.tsx        # Etiquetas SEO head (title, meta, OG) por ruta
+├── Footer.tsx              # Pie de página
+├── LanguageSwitcher.tsx    # Selector de idioma
+├── Layout.tsx              # Wrapper principal de aplicación
+├── MarkdownTable.tsx       # Wrapper estilizado para tablas markdown
+├── Navbar.tsx              # Barra de navegación
+├── NavigationProgress.tsx  # Barra de carga superior en cambios de ruta
+├── OptimizedImage.tsx      # Imágenes responsive + logos SVG, lazy/error states
+├── ParticlesBackground.tsx # Fondo animado de partículas (canvas)
+├── RoutePreloader.tsx     # Pre-carga chunks de ruta al hacer hover en links
+├── ScrollToTop.tsx         # Reinicia scroll al navegar
+├── SkipLinks.tsx           # Links de accesibilidad skip-to-content
+├── ThemeToggle.tsx         # Interruptor de tema claro/oscuro
+└── index.ts                # Exportaciones de componentes
+
+src/pages/
+├── Home/
+├── Projects/
+├── About/
+├── Blog/
+├── Contact/
+└── NotFound.tsx
 ```
+
+> Nota: `OptimizedImage` reemplazó al antiguo componente `OptimizedLogo`, que ya no existe. Logos SVG e imágenes raster son manejados por `OptimizedImage`.
 
 ## 🏗️ Componentes de Layout
 
@@ -851,6 +859,20 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
 }
 ```
 
+## 🧩 Componentes Compartidos Adicionales
+
+Además de los componentes de layout, `src/components/` exporta varias utilidades compartidas usadas entre páginas:
+
+- **`OptimizedImage`** (`OptimizedImage.tsx`): Maneja imágenes raster responsive y logos SVG con lazy loading y estados de error. Reemplazó al antiguo componente `OptimizedLogo`, que ya no existe.
+- **`ThemeToggle`** (`ThemeToggle.tsx`): Interruptor de tema claro/oscuro conectado al proveedor de tema.
+- **`SkipLinks`** (`SkipLinks.tsx`): Links de accesibilidad skip-to-content para usuarios de teclado.
+- **`ScrollToTop`** (`ScrollToTop.tsx`): Reinicia la posición de scroll al cambiar de ruta.
+- **`NavigationProgress`** (`NavigationProgress.tsx`): Barra de carga superior durante transiciones de ruta.
+- **`ParticlesBackground`** (`ParticlesBackground.tsx`): Canvas animado de partículas usado como fondo decorativo.
+- **`DocumentHead`** (`DocumentHead.tsx`): Gestiona etiquetas SEO head (title, meta, Open Graph) por ruta.
+- **`MarkdownTable`** (`MarkdownTable.tsx`): Wrapper estilizado para renderizar tablas markdown.
+- **`RoutePreloader`** (`RoutePreloader.tsx`): Pre-carga chunks de ruta al hacer hover en links para acelerar la navegación.
+
 ## 🧪 Patrones de Pruebas
 
 ### Configuración de Pruebas de Componentes
@@ -997,18 +1019,29 @@ export const mockProject: GitHubProject = {
   topics: ['react', 'typescript', 'vite'],
 }
 
-// test/mocks/handlers.ts
-import { rest } from 'msw'
+// test/mocks/fetch.ts — el proyecto NO usa MSW; se stubbea fetch global con vi
+import { vi } from 'vitest'
 
-export const handlers = [
-  rest.get('/api/projects', (req, res, ctx) => {
-    return res(ctx.json([mockProject]))
-  }),
+// Stub de fetch para pruebas de hooks/servicios que usan fetch nativo
+export function mockFetchResponse(body: unknown, ok = true, status = 200) {
+  const response = {
+    ok,
+    status,
+    json: async () => body,
+  } as Response
 
-  rest.post('/api/contact', (req, res, ctx) => {
-    return res(ctx.json({ success: true }))
-  }),
-]
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response))
+  return vi.mocked(fetch)
+}
+
+// Uso en una prueba:
+// beforeEach(() => {
+//   mockFetchResponse([mockProject])
+// })
+//
+// afterEach(() => {
+//   vi.unstubAllGlobals()
+// })
 ```
 
 ## 📚 Guías de Uso

--- a/docs/es/COMPONENTS.md
+++ b/docs/es/COMPONENTS.md
@@ -883,7 +883,7 @@ import { render, RenderOptions } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
-import i18n from './i18n-test'
+import i18n from '@/test/i18n-for-tests'
 
 const AllTheProviders: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const queryClient = new QueryClient({

--- a/docs/es/DEVELOPMENT.md
+++ b/docs/es/DEVELOPMENT.md
@@ -422,27 +422,40 @@ Para estilos que no se pueden expresar con Tailwind:
 
 ```typescript
 // vite.config.ts (el bloque `test`)
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import { configDefaults } from 'vitest/config'
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(() => ({
+  // ...plugins, resolve, build...
   test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
     globals: true,
-    css: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'e2e/*'],
     coverage: {
-      reporter: ['text', 'json', 'html'],
+      provider: 'v8' as const,
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
+        ...(configDefaults.coverage.exclude ?? []),
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**',
+        'src/**/*.d.ts',
+        'src/types/**',
+        'src/vite-env.d.ts',
+        'src/main.tsx',
+        'src/i18n/**',
+        'src/constants/**',
       ],
+      thresholds: {
+        lines: 20,
+        functions: 15,
+        branches: 15,
+        statements: 20,
+      },
     },
   },
-})
+}))
 ```
 
 ### Escribiendo Pruebas

--- a/docs/es/DEVELOPMENT.md
+++ b/docs/es/DEVELOPMENT.md
@@ -8,8 +8,8 @@ Esta guía proporciona todo lo que necesitas saber para configurar, desarrollar 
 
 Antes de comenzar, asegúrate de tener instalado:
 
-- **Node.js** (v18.0.0 o superior)
-- **pnpm** (v8.0.0 o superior) - Recomendado por rendimiento
+- **Node.js** (v20 o superior)
+- **pnpm** (v10+ - el proyecto fija pnpm 11.x mediante `packageManager`)
 - **Git** (v2.30.0 o superior)
 
 ### Configuración del Entorno
@@ -61,11 +61,14 @@ Antes de comenzar, asegúrate de tener instalado:
 ### Scripts Principales
 
 ```bash
-# Servidor de desarrollo con hot reload
+# Servidor de desarrollo con hot reload (vite --host)
 pnpm dev
 
 # Build de producción
 pnpm build
+
+# Build de producción con análisis del bundle
+pnpm build:analyze
 
 # Preview del build de producción localmente
 pnpm preview
@@ -79,34 +82,32 @@ pnpm test:watch
 # Ejecutar pruebas con reporte de cobertura
 pnpm test:coverage
 
+# Pruebas E2E con Playwright
+pnpm test:e2e
+
 # Linting de código
 pnpm lint
-
-# Corrección automática de problemas de linting
-pnpm lint:fix
 
 # Formateo de código con Prettier
 pnpm format
 
+# Verificación de formato de código
+pnpm format:check
+
+# Linting de documentación
+pnpm docs:lint
+
+# Auto-corrección de linting de documentación
+pnpm docs:lint:fix
+
 # Verificación de tipos TypeScript
 pnpm type-check
+
+# Verificación integral: lint + docs:lint + format:check + type-check
+pnpm quality
 ```
 
-### Scripts de Utilidad
-
-```bash
-# Análisis del tamaño del bundle
-pnpm analyze
-
-# Limpieza de cache y node_modules
-pnpm clean
-
-# Verificación pre-commit (automática con Husky)
-pnpm pre-commit
-
-# Construcción completa con verificaciones
-pnpm build:full
-```
+> Nota: no existe un script `lint:fix`. La auto-corrección de ESLint se ejecuta a través de lint-staged sobre los archivos staged (`eslint . --fix`), o directamente con: `pnpm exec eslint . --fix`.
 
 ## 📁 Estructura del Proyecto
 
@@ -420,7 +421,7 @@ Para estilos que no se pueden expresar con Tailwind:
 ### Configuración Vitest
 
 ```typescript
-// vitest.config.ts
+// vite.config.ts (el bloque `test`)
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
@@ -493,23 +494,39 @@ describe('useCustomHook', () => {
 
 #### Mocking de APIs
 
-```typescript
-// src/test/mocks/handlers.ts
-import { rest } from 'msw'
+El proyecto no usa MSW. Para simular llamadas a la API en las pruebas, stubea el `fetch` global con Vitest:
 
-export const handlers = [
-  rest.get('https://api.github.com/users/:username/repos', (req, res, ctx) => {
-    return res(
-      ctx.json([
-        {
-          id: 1,
-          name: 'proyecto-ejemplo',
-          description: 'Un proyecto de ejemplo',
-        },
-      ])
+```typescript
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetch de proyectos', () => {
+  it('devuelve los proyectos desde la API', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          {
+            id: 1,
+            name: 'proyecto-ejemplo',
+            description: 'Un proyecto de ejemplo',
+          },
+        ],
+      })
     )
-  }),
-]
+
+    const repos = await fetch(
+      'https://api.github.com/users/tuusuario/repos'
+    ).then((r) => r.json())
+
+    expect(repos).toHaveLength(1)
+    expect(repos[0].name).toBe('proyecto-ejemplo')
+  })
+})
 ```
 
 ## 🔧 Herramientas de Desarrollo
@@ -691,20 +708,20 @@ VITE_APP_TITLE=Mi Portafolio
 VITE_APP_DESCRIPTION=Portafolio personal
 ```
 
-#### Scripts de Desarrollo Avanzados
+#### Scripts de Desarrollo Adicionales
 
 ```bash
-# Desarrollo con análisis de bundle
-pnpm dev:analyze
+# Build de producción con análisis de bundle
+pnpm build:analyze
 
-# Desarrollo con proxy de API
-pnpm dev:api
+# Análisis de presupuesto de rendimiento
+pnpm performance:budget
 
-# Desarrollo con modo strict de React
-pnpm dev:strict
+# Lighthouse CI
+pnpm lighthouse:ci
 
-# Build con optimizaciones adicionales
-pnpm build:optimized
+# Genera snapshot de proyectos
+pnpm generate:projects-snapshot
 ```
 
 ## 🐛 Debugging

--- a/docs/es/I18N.md
+++ b/docs/es/I18N.md
@@ -35,53 +35,37 @@ pnpm add react-i18next i18next i18next-browser-languagedetector
 
 ```typescript
 // src/i18n/i18n.ts
-import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 
 // Importar recursos de traducción
-import enTranslation from '../locales/en/translation.json'
-import esTranslation from '../locales/es/translation.json'
+import translationEN from '../locales/en/translation.json'
+import translationES from '../locales/es/translation.json'
 
-const resources = {
-  en: {
-    translation: enTranslation,
-  },
-  es: {
-    translation: esTranslation,
-  },
-}
-
-i18n
+void i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources,
-    lng: 'en', // idioma por defecto
-    fallbackLng: 'en',
-    
+    resources: {
+      en: {
+        translation: translationEN,
+      },
+      es: {
+        translation: translationES,
+      },
+    },
+    fallbackLng: 'es',
+    supportedLngs: ['es', 'en'],
+
     // Configuración de detección
     detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
-      caches: ['localStorage'],
+      order: ['path', 'navigator'],
     },
-    
+
     // Configuración de interpolación
     interpolation: {
       escapeValue: false, // React ya maneja XSS
-    },
-    
-    // Configuración de debugging
-    debug: import.meta.env.DEV,
-    
-    // Configuración de react-i18next
-    react: {
-      useSuspense: false,
-      bindI18n: 'languageChanged',
-      bindI18nStore: '',
-      transEmptyNodeValue: '',
-      transSupportBasicHtmlNodes: true,
-      transKeepBasicHtmlNodesFor: ['br', 'strong', 'i'],
     },
   })
 
@@ -112,9 +96,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 src/locales/
 ├── en/
 │   └── translation.json     # Traducciones en inglés
-├── es/
-│   └── translation.json     # Traducciones en español
-└── index.ts                 # Tipos TypeScript para traducciones
+└── es/
+    └── translation.json     # Traducciones en español
 ```
 
 ### Estructura de Archivo de Traducción

--- a/docs/es/I18N.md
+++ b/docs/es/I18N.md
@@ -650,7 +650,7 @@ export const useNumberFormat = () => {
 ### Configuración de i18n para Pruebas
 
 ```typescript
-// src/test/i18n-test.ts
+// src/test/i18n-for-tests.ts
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
@@ -678,8 +678,8 @@ const resources = {
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: 'en',
-  fallbackLng: 'en',
+  lng: 'es',
+  fallbackLng: 'es',
   interpolation: {
     escapeValue: false
   },
@@ -697,7 +697,7 @@ export default i18n
 // src/components/__tests__/LanguageSwitcher.test.tsx
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
-import i18n from '@/test/i18n-test'
+import i18n from '@/test/i18n-for-tests'
 import { LanguageSwitcher } from '../LanguageSwitcher'
 
 const renderWithI18n = (component: React.ReactElement, language = 'en') => {

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -65,7 +65,7 @@ pnpm preview
 
 ### Tecnologías Principales
 
-- **React 19.0** - Biblioteca de UI
+- **React 19.2** - Biblioteca de UI
 - **TypeScript 5.9** - Seguridad de tipos
 - **Vite 8.0** - Herramienta de build y servidor de desarrollo
 - **Tailwind CSS 4.2** - Framework CSS utility-first
@@ -109,8 +109,10 @@ mywebsite-2/
 │   ├── lib/              # Bibliotecas de utilidades
 │   ├── locales/          # Archivos de traducción
 │   ├── router/           # Configuración de enrutamiento
+│   ├── styles/           # Estilos globales
 │   ├── utils/            # Utilidades generales
-│   └── styles/           # Estilos globales
+│   ├── types/            # Tipos TypeScript compartidos
+│   └── types.ts          # Tipos TypeScript globales
 └── ...archivos de configuración
 ```
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -1,9 +1,9 @@
 # Miguel Ángel de Dios - Portafolio Personal 🚀
 
 [![React](https://img.shields.io/badge/React-19.0.0-blue.svg)](https://reactjs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue.svg)](https://www.typescriptlang.org/)
-[![Vite](https://img.shields.io/badge/Vite-6.0-646CFF.svg)](https://vitejs.dev/)
-[![Tailwind CSS](https://img.shields.io/badge/Tailwind%20CSS-4.0-38B2AC.svg)](https://tailwindcss.com/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
+[![Vite](https://img.shields.io/badge/Vite-8.0-646CFF.svg)](https://vitejs.dev/)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind%20CSS-4.2-38B2AC.svg)](https://tailwindcss.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Portafolio personal moderno y responsivo construido con React, TypeScript y tecnologías web de vanguardia.
@@ -66,19 +66,18 @@ pnpm preview
 ### Tecnologías Principales
 
 - **React 19.0** - Biblioteca de UI
-- **TypeScript 5.6** - Seguridad de tipos
-- **Vite 6.0** - Herramienta de build y servidor de desarrollo
-- **Tailwind CSS 4.0** - Framework CSS utility-first
+- **TypeScript 5.9** - Seguridad de tipos
+- **Vite 8.0** - Herramienta de build y servidor de desarrollo
+- **Tailwind CSS 4.2** - Framework CSS utility-first
 
 ### Bibliotecas Clave
 
-- **Framer Motion** - Biblioteca de animaciones
-- **React Router** - Enrutamiento del lado del cliente
-- **React Hook Form** - Gestión de formularios
-- **React Query (TanStack)** - Gestión de estado del servidor
-- **React i18next** - Internacionalización
-- **Zustand** - Gestión de estado global
-- **Axios** - Cliente HTTP
+- **Framer Motion 12.38** - Biblioteca de animaciones
+- **React Router 7.17** - Enrutamiento del lado del cliente
+- **React Hook Form 7.72** - Gestión de formularios
+- **React Query (TanStack) 5.95** - Gestión de estado del servidor
+- **React i18next 15.7** - Internacionalización
+- **Zod 4.3** - Validación de esquemas
 
 ### Herramientas de Desarrollo
 
@@ -102,10 +101,15 @@ mywebsite-2/
 ├── src/
 │   ├── components/        # Componentes UI reutilizables
 │   ├── pages/            # Componentes de páginas
+│   ├── content/          # Contenido markdown del blog
+│   ├── context/          # Proveedores de contexto de React
+│   ├── data/             # Fuentes de datos estáticos
 │   ├── hooks/            # Hooks personalizados de React
+│   ├── i18n/             # Configuración de internacionalización
 │   ├── lib/              # Bibliotecas de utilidades
 │   ├── locales/          # Archivos de traducción
 │   ├── router/           # Configuración de enrutamiento
+│   ├── utils/            # Utilidades generales
 │   └── styles/           # Estilos globales
 └── ...archivos de configuración
 ```
@@ -116,6 +120,7 @@ mywebsite-2/
 - **📁 Proyectos**: Showcase de portafolio de GitHub con demos en vivo
 - **👤 Sobre Mí**: Información personal, habilidades y experiencia
 - **📬 Contacto**: Formulario de contacto con validación reCAPTCHA
+- **📝 Blog**: Publicaciones basadas en markdown con soporte multiidioma
 
 ## 🔧 Scripts Disponibles
 

--- a/docs/es/TESTING.md
+++ b/docs/es/TESTING.md
@@ -35,94 +35,62 @@ El proyecto implementa una estrategia de pruebas integral que abarca múltiples 
 ### Vitest - Framework de Pruebas
 
 ```typescript
-// vitest.config.ts
-import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
-import { resolve } from 'path'
+// vite.config.ts (el bloque `test`)
+import { configDefaults } from 'vitest/config'
+// ...plugins de vite, resolve.alias, build...
 
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(() => ({
+  // ...plugins, resolve, build...
   test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
     globals: true,
-    css: true,
-    
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'e2e/*'],
+
     // Configuración de cobertura
     coverage: {
+      provider: 'v8' as const,
       reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
-        'dist/',
-        'build/',
-        'coverage/',
-        '**/*.test.{ts,tsx}',
-        '**/*.spec.{ts,tsx}'
+        ...(configDefaults.coverage.exclude ?? []),
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**',
+        'src/**/*.d.ts',
+        'src/types/**',
+        'src/vite-env.d.ts',
+        'src/main.tsx',
+        'src/i18n/**',
+        'src/constants/**',
       ],
-      // Umbrales de cobertura
-      statements: 80,
-      branches: 75,
-      functions: 80,
-      lines: 80
+      // Umbrales de cobertura (intencionalmente bajos)
+      thresholds: {
+        lines: 20,
+        functions: 15,
+        branches: 15,
+        statements: 20,
+      },
     },
-    
-    // Configuración de watch
-    watch: {
-      exclude: ['node_modules', 'dist', 'build']
-    },
-    
-    // Configuración de timeouts
-    testTimeout: 10000,
-    hookTimeout: 10000
   },
-  
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, './src'),
-      '@/test': resolve(__dirname, './src/test')
-    }
-  }
-})
+}))
 ```
 
 ### Configuración Inicial de Pruebas
 
 ```typescript
 // src/test/setup.ts
-import '@testing-library/jest-dom'
-import { expect, afterEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeAll, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
-import * as matchers from '@testing-library/jest-dom/matchers'
 
-// Extender matchers de jest-dom
-expect.extend(matchers)
+// Importar y configurar i18n para pruebas
+import './i18n-for-tests'
 
-// Limpiar después de cada prueba
-afterEach(() => {
-  cleanup()
-})
-
-// Mock de IntersectionObserver
-global.IntersectionObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn()
-}))
-
-// Mock de ResizeObserver
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-  disconnect: vi.fn()
-}))
-
-// Mock de matchMedia
-Object.defineProperty(window, 'matchMedia', {
+// Mock de window.matchMedia para componentes que usan useReducedMotion
+Object.defineProperty(globalThis, 'matchMedia', {
   writable: true,
-  value: vi.fn().mockImplementation(query => ({
+  value: vi.fn().mockImplementation((query: string) => ({
     matches: false,
     media: query,
     onchange: null,
@@ -131,107 +99,84 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
-  }))
+  })),
 })
 
-// Mock de scrollTo
-Object.defineProperty(window, 'scrollTo', {
+// Mock de IntersectionObserver para framer-motion whileInView en jsdom
+class MockIntersectionObserver {
+  readonly root = null
+  readonly rootMargin = ''
+  readonly thresholds: number[] = []
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+}
+Object.defineProperty(globalThis, 'IntersectionObserver', {
   writable: true,
-  value: vi.fn()
+  value: MockIntersectionObserver,
 })
 
-// Variables de entorno para pruebas
-vi.mock('../env', () => ({
-  VITE_API_URL: 'http://localhost:3000/api',
-  VITE_RECAPTCHA_SITE_KEY: 'test-recaptcha-key'
-}))
+// Silenciar errores de consola conocidos en pruebas
+const originalError = console.error
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    const firstArg = args[0]
+    const message =
+      firstArg instanceof Error ? firstArg.message : typeof firstArg === 'string' ? firstArg : JSON.stringify(firstArg)
+    if (message.includes('Error sending message') || message.includes('Validation error')) return
+    originalError(...args)
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 ```
 
 ### Utilidades de Pruebas Personalizadas
 
 ```typescript
 // src/test/utils.tsx
-import React, { ReactElement } from 'react'
-import { render, RenderOptions } from '@testing-library/react'
+import { ReactElement } from 'react'
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'
-import i18n from './i18n-test'
+
+import { render, RenderOptions, RenderResult } from '@testing-library/react'
+
+import i18n from './i18n-for-tests'
 
 // Configuración de QueryClient para pruebas
-const createTestQueryClient = () => new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-      staleTime: Infinity,
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
     },
-    mutations: {
-      retry: false,
-    },
-  },
-  logger: {
-    log: console.log,
-    warn: console.warn,
-    error: () => {}, // Silenciar errores en pruebas
-  },
-})
+  })
 
-// Providers combinados para pruebas
-const AllTheProviders: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const queryClient = createTestQueryClient()
-  
-  return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <I18nextProvider i18n={i18n}>
-          {children}
-        </I18nextProvider>
-      </BrowserRouter>
-    </QueryClientProvider>
-  )
-}
-
-// Función de render personalizada
-const customRender = (
+// Función de render con todos los providers
+export function renderWithProviders(
   ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>
-) => render(ui, { wrapper: AllTheProviders, ...options })
-
-// Función de render con providers específicos
-export const renderWithProviders = (
-  ui: ReactElement,
-  {
-    preloadedState = {},
-    queryClient = createTestQueryClient(),
-    route = '/',
-    ...renderOptions
-  }: {
-    preloadedState?: any
-    queryClient?: QueryClient
-    route?: string
-  } & Omit<RenderOptions, 'wrapper'> = {}
-) => {
-  window.history.pushState({}, 'Test page', route)
-  
-  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <I18nextProvider i18n={i18n}>
-          {children}
-        </I18nextProvider>
-      </BrowserRouter>
-    </QueryClientProvider>
-  )
-  
-  return {
-    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
-    queryClient
-  }
+  options?: Omit<RenderOptions, 'wrapper'>,
+): RenderResult {
+  const testQueryClient = createTestQueryClient()
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={testQueryClient}>
+        <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+      </QueryClientProvider>
+    ),
+    ...options,
+  })
 }
-
-// Re-exportar todo de testing-library
-export * from '@testing-library/react'
-export { customRender as render }
 ```
 
 ## 🧪 Pruebas Unitarias
@@ -242,9 +187,8 @@ export { customRender as render }
 // src/hooks/__tests__/useProjects.test.ts
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useProjects } from '../useProjects'
-import { server } from '@/test/server'
-import { http, HttpResponse } from 'msw'
 
 // Mock data
 const mockProjects = [
@@ -266,7 +210,7 @@ const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } }
   })
-  
+
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
       {children}
@@ -275,65 +219,76 @@ const createWrapper = () => {
 }
 
 describe('useProjects', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('obtiene proyectos exitosamente', async () => {
-    server.use(
-      http.get('/api/projects', () => {
-        return HttpResponse.json(mockProjects)
-      })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockProjects),
+      } as Response),
     )
-    
+
     const { result } = renderHook(() => useProjects(), {
       wrapper: createWrapper()
     })
-    
+
     expect(result.current.isLoading).toBe(true)
-    
+
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
-    
+
     expect(result.current.data).toEqual(mockProjects)
     expect(result.current.isLoading).toBe(false)
   })
-  
+
   it('maneja errores correctamente', async () => {
-    server.use(
-      http.get('/api/projects', () => {
-        return new HttpResponse(null, { status: 500 })
-      })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ message: 'Server error' }),
+      } as Response),
     )
-    
+
     const { result } = renderHook(() => useProjects(), {
       wrapper: createWrapper()
     })
-    
+
     await waitFor(() => {
       expect(result.current.isError).toBe(true)
     })
-    
+
     expect(result.current.error).toBeDefined()
   })
-  
+
   it('filtra proyectos excluidos', async () => {
     const projectsWithExcluded = [
       ...mockProjects,
       { ...mockProjects[0], id: 334629076 } // Proyecto excluido
     ]
-    
-    server.use(
-      http.get('/api/projects', () => {
-        return HttpResponse.json(projectsWithExcluded)
-      })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(projectsWithExcluded),
+      } as Response),
     )
-    
+
     const { result } = renderHook(() => useProjects(), {
       wrapper: createWrapper()
     })
-    
+
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
-    
+
     expect(result.current.data).toHaveLength(1)
     expect(result.current.data?.[0].id).toBe(1)
   })
@@ -407,8 +362,19 @@ describe('animations', () => {
 ```typescript
 // src/components/__tests__/ProjectCard.test.tsx
 import { render, screen, fireEvent, waitFor } from '@/test/utils'
+import { vi } from 'vitest'
 import { ProjectCard } from '../ProjectCard'
-import { mockProject } from '@/test/mocks'
+
+const mockProject = {
+  id: 1,
+  name: 'awesome-project',
+  description: 'An awesome project built with React and TypeScript',
+  html_url: 'https://github.com/user/awesome-project',
+  language: 'TypeScript',
+  stargazers_count: 42,
+  forks_count: 7,
+  topics: ['react', 'typescript'],
+}
 
 describe('ProjectCard', () => {
   const defaultProps = {
@@ -484,9 +450,8 @@ describe('ProjectCard', () => {
 ```typescript
 // src/pages/Contact/components/__tests__/ContactForm.test.tsx
 import { render, screen, fireEvent, waitFor } from '@/test/utils'
+import { vi } from 'vitest'
 import { ContactForm } from '../ContactForm'
-import { server } from '@/test/server'
-import { http, HttpResponse } from 'msw'
 
 describe('ContactForm', () => {
   const mockOnSubmit = vi.fn()
@@ -539,12 +504,14 @@ describe('ContactForm', () => {
       message: 'Este es un mensaje de prueba'
     }
     
-    server.use(
-      http.post('/api/contact', () => {
-        return HttpResponse.json({ success: true })
-      })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      } as Response),
     )
-    
+
     render(<ContactForm onSubmit={mockOnSubmit} />)
     
     fireEvent.change(screen.getByLabelText(/nombre/i), {
@@ -795,57 +762,51 @@ test.describe('Rendimiento', () => {
 
 ## 🎯 Mocking y Fixtures
 
-### Mock Service Worker (MSW)
+### Mocking de APIs con `fetch`
+
+El proyecto no usa MSW. Las llamadas a la API se mockean stubbeando el `fetch` global con `vi.fn()` / `vi.stubGlobal('fetch', ...)` y mockeando módulos con `vi.mock(...)`.
 
 ```typescript
-// src/test/server.ts
-import { setupServer } from 'msw/node'
-import { handlers } from './handlers'
+// Ejemplo: stub de fetch para una prueba
+import { vi } from 'vitest'
 
-export const server = setupServer(...handlers)
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    } as Response),
+  )
+})
 
-// Configuración en setup.ts
-beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 ```
 
-```typescript
-// src/test/handlers.ts
-import { http, HttpResponse } from 'msw'
-import { mockProjects, mockContactResponse } from './mocks'
+Para sobrescribir el comportamiento en una prueba concreta, vuelve a stubbear `fetch` dentro del test o usa `vi.mocked(fetch).mockResolvedValueOnce(...)`.
 
-export const handlers = [
-  // Mock API de proyectos
-  http.get('https://api.github.com/users/:username/repos', ({ params }) => {
-    return HttpResponse.json(mockProjects)
-  }),
-  
-  // Mock formulario de contacto
-  http.post('/api/contact', async ({ request }) => {
-    const body = await request.json()
-    
-    if (body.email === 'error@example.com') {
-      return new HttpResponse(null, { status: 500 })
-    }
-    
-    return HttpResponse.json(mockContactResponse)
-  }),
-  
-  // Mock reCAPTCHA
-  http.post('https://www.google.com/recaptcha/api/siteverify', () => {
-    return HttpResponse.json({ success: true })
-  })
-]
+### Mocking de Módulos
+
+```typescript
+import { vi } from 'vitest'
+
+// Mock de un módulo completo
+vi.mock('@/services/projects', () => ({
+  fetchProjects: vi.fn().mockResolvedValue([{ id: 1, name: 'mock-project' }]),
+}))
 ```
 
 ### Fixtures de Datos
 
+Los datos de prueba se definen inline dentro de cada test (o en un archivo co-localizado junto al test). No existe un directorio `src/test/mocks/`.
+
 ```typescript
-// src/test/mocks/projects.ts
+// Datos de ejemplo definidos inline en el test
 import type { GitHubProject } from '@/types'
 
-export const mockProject: GitHubProject = {
+const mockProject: GitHubProject = {
   id: 1,
   name: 'awesome-project',
   full_name: 'user/awesome-project',
@@ -869,7 +830,7 @@ export const mockProject: GitHubProject = {
   disabled: false
 }
 
-export const mockProjects: GitHubProject[] = [
+const mockProjects: GitHubProject[] = [
   mockProject,
   {
     ...mockProject,
@@ -889,33 +850,39 @@ export const mockProjects: GitHubProject[] = [
 ### Configuración de Umbrales
 
 ```typescript
-// vitest.config.ts - configuración de cobertura
-export default defineConfig({
+// vite.config.ts (el bloque `test`) - configuración de cobertura
+export default defineConfig(() => ({
   test: {
     coverage: {
-      // Umbrales mínimos de cobertura
-      statements: 80,
-      branches: 75,
-      functions: 80,
-      lines: 80,
-      
-      // Archivos a excluir
+      // Umbrales mínimos de cobertura (intencionalmente bajos)
+      thresholds: {
+        lines: 20,
+        functions: 15,
+        branches: 15,
+        statements: 20,
+      },
+
+      // Archivos a incluir / excluir
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
-        'node_modules/',
-        'src/test/',
-        '**/*.d.ts',
-        '**/*.config.*',
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/test/**',
+        'src/**/*.d.ts',
+        'src/types/**',
+        'src/vite-env.d.ts',
         'src/main.tsx',
-        'src/vite-env.d.ts'
+        'src/i18n/**',
+        'src/constants/**',
       ],
-      
+
       // Reportes de cobertura
       reporter: ['text', 'json', 'html', 'lcov'],
-      reportsDirectory: './coverage'
     }
   }
-})
+}))
 ```
+
+> Nota: los umbrales enforceados por la configuración son bajos (líneas/sentencias 20%, funciones/ramas 15%) para mantener el CI en verde mientras la cobertura crece. Los objetivos más altos (90%+ en componentes, 95%+ en utils) son aspiracionales, no puertas de CI.
 
 ### Scripts de Cobertura
 
@@ -923,9 +890,7 @@ export default defineConfig({
 {
   "scripts": {
     "test:coverage": "vitest run --coverage",
-    "test:coverage:watch": "vitest --coverage",
-    "test:coverage:ui": "vitest --ui --coverage",
-    "coverage:open": "open coverage/index.html"
+    "test:coverage:ui": "vitest --ui --coverage"
   }
 }
 ```
@@ -1026,8 +991,7 @@ src/
 └── test/
     ├── setup.ts
     ├── utils.tsx
-    ├── mocks/
-    └── fixtures/
+    └── i18n-for-tests.ts
 ```
 
 Esta guía de pruebas proporciona un marco completo para mantener alta calidad de código a través de testing efectivo. Para más detalles sobre configuración específica, consulta los archivos de configuración en el directorio raíz del proyecto.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,7 +79,7 @@ export default defineConfig(() => ({
             // Data fetching, forms, validation, HTTP
             {
               name: 'data-vendor',
-              test: /node_modules[\\/](@tanstack|react-hook-form|@hookform|zod|axios)[\\/]/,
+              test: /node_modules[\\/](@tanstack|react-hook-form|@hookform|zod)[\\/]/,
               priority: 10,
             },
             // Internationalisation


### PR DESCRIPTION
## What

Updates all documentation in `docs/` (EN+ES, excluding blog) to match the current codebase after prior refactors, and removes a dead `axios` reference in `vite.config.ts`.

## Docs changes (EN+ES)
- Stack versions brought up to date: React 19.2, Vite 8, TypeScript 5.9, Tailwind 4.2, React Router 7.17, Framer Motion 12.38, TanStack Query 5.95, etc.
- `axios` → native `fetch` (axios was removed in a prior refactor).
- MSW sections replaced with the actual approach: `vi.stubGlobal('fetch', ...)` / `vi.mock`.
- Vitest config: fixed location (`test` block in `vite.config.ts`, not `vitest.config.ts`) and real coverage thresholds (15-20%, not 80%).
- Removed nonexistent scripts; added Blog page; corrected `src/` trees; Playwright in present tense; i18n config (fallbackLng 'es').
- `RECAPTCHA_SETUP.md` left untouched (was already correct).

## Code change
- `vite.config.ts`: removed `|axios` from the `data-vendor` chunk-group regex (dead entry).

## Verification
- `pnpm docs:lint` passes clean.
- `pnpm type-check` passes.