### PR TITLE
fix(lint): clear 4 deferred warnings (purity + preserve-caught-error)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,10 +25,11 @@ const LinkedInIcon = (props: React.ComponentProps<'svg'>) => (
   </svg>
 )
 
+const currentYear = new Date().getFullYear()
+
 export default function Footer() {
   const { t, i18n } = useTranslation()
   const { isDark } = useThemeContext()
-  const currentYear = new Date().getFullYear()
 
   const githubUsername = import.meta.env.VITE_GITHUB_USERNAME ?? ''
   const linkedinUsername = import.meta.env.VITE_LINKEDIN_USERNAME ?? ''

--- a/src/hooks/useBlog.ts
+++ b/src/hooks/useBlog.ts
@@ -136,7 +136,7 @@ async function loadBlogPosts(language: BlogLanguage): Promise<BlogPost[]> {
     return posts
   } catch (err) {
     console.error('Error loading blog posts:', err)
-    throw new Error('Error al cargar los posts del blog')
+    throw new Error('Error al cargar los posts del blog', { cause: err })
   }
 }
 

--- a/src/hooks/useProjectCaseStudies.ts
+++ b/src/hooks/useProjectCaseStudies.ts
@@ -123,7 +123,7 @@ async function loadCaseStudies(language: CaseStudyLanguage): Promise<ProjectCase
     return caseStudies
   } catch (err) {
     console.error('Error loading case studies:', err)
-    throw new Error('Error al cargar los estudios de casos')
+    throw new Error('Error al cargar los estudios de casos', { cause: err })
   }
 }
 

--- a/src/pages/Contact/hooks/useContactForm.ts
+++ b/src/pages/Contact/hooks/useContactForm.ts
@@ -71,7 +71,7 @@ const submitContactForm = async (data: ContactFormData, recaptchaToken: string):
   } catch (error) {
     if (error instanceof z.ZodError) {
       const errorMessages = error.issues.map((issue) => issue.message).join(', ')
-      throw new Error(`Validation error: ${errorMessages}`)
+      throw new Error(`Validation error: ${errorMessages}`, { cause: error })
     }
     throw error
   }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## What

Clears the 4 lint warnings deferred during the ESLint 10 upgrade (PR #72).

- **Footer.tsx**: `new Date().getFullYear()` moved out of the render body to module scope → fixes `react-x/purity` (no impure calls during render). Fine for a copyright year.
- **useBlog.ts:139 / useProjectCaseStudies.ts:126 / useContactForm.ts:74**: attach `{ cause }` to rethrown errors → fixes `preserve-caught-error` (error chain preserved for debugging).
- **tsconfig.app.json**: `lib` ES2020 → ES2022 so `ErrorOptions` (the `{ cause }` 2nd arg) typechecks. `target` stays ES2020 (runtime emit unchanged); matches the ES2023 lib already in tsconfig.node.json. Additive type-only change.

## Why

Tech debt from PR #72 — these were silenced as warnings to keep that bump clean. Now resolved properly (real fixes, not rule disables).

## Verified

- lint: **0 errors, 0 warnings**
- `tsc -b`: clean
- 139/139 tests (17 files)

Delegated the edits to a fixer subagent; diff reviewed manually before commit.