### PR TITLE
chore(docker): pin base images by sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # ============================================================
 # Stage 1: Builder
 # ============================================================
-FROM node:24.18.0-alpine3.24 AS builder
+# node:24.18.0-alpine3.24 (multi-arch manifest-list digest, amd64+arm64+s390x)
+FROM node:24.18.0-alpine3.24@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
 
 # Upgrade all system packages to latest patched versions
 RUN apk upgrade --no-cache
@@ -44,7 +45,8 @@ RUN GITHUB_TOKEN=$GITHUB_TOKEN pnpm run build
 # ============================================================
 # nginxinc/nginx-unprivileged: runs as non-root (uid 101),
 # Alpine base, minimal attack surface for static file serving
-FROM nginxinc/nginx-unprivileged:1.31.2-alpine3.23 AS production
+# nginxinc/nginx-unprivileged:1.31.2-alpine3.23 (multi-arch manifest-list digest, amd64+arm64+arm/v7+ppc64le+s390x+riscv64)
+FROM nginxinc/nginx-unprivileged:1.31.2-alpine3.23@sha256:054e14f543eb688809d59ec2ad1644d1a61678e247c87a318ad605977eb37eaf AS production
 
 USER root
 RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*


### PR DESCRIPTION
## What

Pin both Dockerfile base images to their multi-arch manifest-list `@sha256` digest, keeping the readable tag as a comment.

- `node:24.18.0-alpine3.24` → `@sha256:a0b9bf06...` (index: amd64+arm64+s390x)
- `nginxinc/nginx-unprivileged:1.31.2-alpine3.23` → `@sha256:054e14f5...` (index: amd64+arm64+arm/v7+ppc64le+s390x+riscv64)

## Why

Tags are mutable — upstream can re-point `24.18.0-alpine3.24` to a different image. The digest can't. This makes builds reproducible and prevents a silent base-image swap.

## Notes

- Both digests are **manifest-list / OCI index** digests (not per-arch), so amd64 and arm64 Dokploy builders both resolve correctly.
- Resolved via the Docker Hub registry HTTP API (`Docker-Content-Digest` header) — no daemon needed.
- To update a base image later: bump the tag in the comment, re-resolve the digest, update both.

Dockerfile-only change. Delegated digest resolution to a fixer subagent; diff reviewed manually.