### PR TITLE
chore(security): drop script-src 'unsafe-inline' via sha256 hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
       Theme anti-FOUC IIFE: applies dark/light class before React hydrates.
       Intentionally duplicates useTheme.ts logic — this is the "first paint" guard,
       the hook syncs React state with the pre-applied class afterward.
+
+      WARNING: This inline script's content is PINNED by a sha256 hash in the
+      `script-src` directive of nginx.conf (both CSP blocks). Changing even a single
+      character of this script requires regenerating the hash and updating BOTH CSP
+      blocks in nginx.conf, or the browser will block this script (theme FOUC).
+      Regenerate with:
+        printf '%s' "<script content bytes>" | openssl dgst -sha256 -binary | openssl base64
     -->
     <script>
       (function() {

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,8 +24,14 @@ server {
         application/atom+xml
         image/svg+xml;
 
-    # TODO: remove 'unsafe-inline' by using nonce/hash for inline scripts
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';" always;
+    # CSP script-src uses a sha256 hash pinning the inline theme anti-FOUC IIFE in index.html.
+    # If that inline script changes, regenerate the hash and update BOTH CSP blocks below
+    # (this one and the one in the /index.html location block) or the theme script will be
+    # blocked by the browser. Regenerate with:
+    #   printf '%s' "<script content bytes>" | openssl dgst -sha256 -binary | openssl base64
+    # NOTE: style-src 'unsafe-inline' is intentionally retained (React inline styles +
+    # a runtime <style> in NavigationProgress.tsx); do NOT remove it.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-yQ4Ff4aH6RVfOUn3nq0Yg2lUf+mcpKWbhUZ2+FBUw7k=' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
@@ -45,8 +51,13 @@ server {
         add_header Pragma "no-cache";
         add_header Expires "0";
         # Re-add security headers (add_header is not inherited in sub-location blocks)
-        # TODO: remove 'unsafe-inline' by using nonce/hash for inline scripts
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';" always;
+        # CSP script-src uses a sha256 hash pinning the inline theme anti-FOUC IIFE in index.html.
+        # If that inline script changes, regenerate the hash and update BOTH CSP blocks
+        # (this one and the one in the server block above) or the theme script will be blocked.
+        # Regenerate with:
+        #   printf '%s' "<script content bytes>" | openssl dgst -sha256 -binary | openssl base64
+        # NOTE: style-src 'unsafe-inline' is intentionally retained; do NOT remove it.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-yQ4Ff4aH6RVfOUn3nq0Yg2lUf+mcpKWbhUZ2+FBUw7k=' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://rsms.me; font-src 'self' https://fonts.gstatic.com https://rsms.me; img-src 'self' data: https:; connect-src 'self' https://mywebsite-umami.mddiosc.cloud https://www.google.com https://www.gstatic.com https://formspree.io; frame-src 'self' https://www.google.com https://www.gstatic.com; frame-ancestors 'none';" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## What

Remove `'unsafe-inline'` from the CSP **script-src** by pinning the one inline script (the theme anti-FOUC IIFE in index.html) with its sha256 hash: `sha256-yQ4Ff4aH6RVfOUn3nq0Yg2lUf+mcpKWbhUZ2+FBUw7k=`. Applied to both CSP blocks (server + /index.html location), kept byte-identical.

## What did NOT change (deliberately)

`style-src 'unsafe-inline'` **stays**. React inline styles + a runtime `<style>` in NavigationProgress.tsx require it; removing it isn't safe without source changes and runtime validation. A static nginx SPA can't do per-request nonces, and hashing every React inline style isn't feasible. So this PR hardens what's safely hardenable.

## Maintenance gotcha (documented in-code)

The hash pins the exact bytes of the inline theme script. **If that script changes, the hash must be regenerated** (`... | openssl dgst -sha256 -binary | openssl base64`) in BOTH CSP blocks, or the browser blocks it → theme FOUC. Warning comments added in nginx.conf (both blocks) and above the script in index.html.

## Verified

- Hash recomputed from the actual served bytes — confirmed Vite does **not** transform the inline script (source == dist), so the hash is stable.
- Both CSP blocks byte-identical.
- 139/139 tests.

Note: the original research handed me a stale hash; the fixer subagent caught the mismatch and stopped instead of shipping a broken CSP — hash was reconciled against the real build before applying.

## Research basis

Confirmed via Vite docs + MDN CSP: for a static SPA, hash-based is the only static-friendly way to drop script-src 'unsafe-inline' (no SSR for nonces); style-src 'unsafe-inline' removal is not realistic here.