### PR TITLE
refactor(react): re-enable set-state-in-effect rule (derive state, no effect)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,13 +55,12 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       ...reactX.configs['recommended-typescript'].rules,
       ...reactDom.configs.recommended.rules,
-      // ponytail: react-hooks v7 / react-x v5 added strict compiler rules that flag
-      // existing, correct code. Silenced here to keep the v10 bump a pure dependency
-      // change; revisit in a dedicated refactor. Upgrade path: re-enable + fix per rule.
+      // ponytail: @floating-ui's API is to pass its `setFloating` ref-setter to ref=,
+      // which react-hooks/refs misreads as accessing a ref during render. Genuine false
+      // positive (BlogList.tsx, ProjectCard.tsx) — stays off. set-state-in-effect was
+      // re-enabled after refactoring the 3 real sites (useReducedMotion/Navbar/useTheme)
+      // to derive state during render instead of setState-in-effect.
       'react-hooks/refs': 'off', // false positive on @floating-ui setFloating callback refs
-      'react-x/set-state-in-effect': 'off', // legit matchMedia/theme sync effects
-      'react-hooks/set-state-in-effect': 'off', // same rule, react-hooks namespace
-      'preserve-caught-error': 'warn', // real but stylistic ({ cause } on rethrow) — defer
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'prettier/prettier': ['error', {}, { usePrettierrc: true }],
       'unused-imports/no-unused-imports': 'error',

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,15 +19,20 @@ import { useThemeContext } from '../context'
 import { LanguageSwitcher, OptimizedImage, ThemeToggle } from '.'
 
 export default function Navbar() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [isScrolled, setIsScrolled] = useState(false)
   const { t, i18n } = useTranslation()
   const { isDark } = useThemeContext()
   const location = useLocation()
 
-  useEffect(() => {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [isScrolled, setIsScrolled] = useState(false)
+  const [menuPathname, setMenuPathname] = useState(location.pathname)
+
+  // Close mobile menu on route change — adjust state during render (not in effect)
+  // so the react-compiler set-state-in-effect rule stays satisfied.
+  if (location.pathname !== menuPathname) {
+    setMenuPathname(location.pathname)
     setMobileMenuOpen(false)
-  }, [location.pathname])
+  }
 
   // Lock body scroll when mobile menu is open
   useEffect(() => {

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -26,28 +26,23 @@ import { useEffect, useState } from 'react'
  * ```
  */
 export const useReducedMotion = (): boolean => {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() =>
+    typeof window === 'undefined'
+      ? false
+      : window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  )
 
   useEffect(() => {
-    // Check if we're in a browser environment
-    if (typeof window === 'undefined') {
-      return
-    }
+    if (typeof window === 'undefined') return
 
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    // Set initial state
-    setPrefersReducedMotion(mediaQuery.matches)
-
-    // Listen for changes
     const handleChange = (event: MediaQueryListEvent) => {
       setPrefersReducedMotion(event.matches)
     }
 
-    // Add event listener
     mediaQuery.addEventListener('change', handleChange)
 
-    // Cleanup
     return () => {
       mediaQuery.removeEventListener('change', handleChange)
     }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -30,67 +30,52 @@ export function useTheme() {
     return 'system'
   })
 
-  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
-
-  // Get the actual theme based on system preference
-  const getResolvedTheme = useCallback((): 'light' | 'dark' => {
-    if (theme === 'system') {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- SSR safety guard
-      if (globalThis.window !== undefined) {
-        return globalThis.window.matchMedia('(prefers-color-scheme: dark)').matches
-          ? 'dark'
-          : 'light'
-      }
-      return 'light'
+  // Track the live system preference so `resolvedTheme` can be derived during
+  // render (no setState-in-effect). Listener stays always-on so this stays fresh
+  // even while `theme` is an explicit 'light'/'dark', matching the previous
+  // live matchMedia read on theme switch.
+  const [systemPref, setSystemPref] = useState<'light' | 'dark'>(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- SSR safety guard
+    if (globalThis.window !== undefined) {
+      return globalThis.window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
     }
-    return theme
-  }, [theme])
+    return 'light'
+  })
 
-  // Update document class and resolved theme
+  // Resolved theme is derived from `theme` + system preference — computed during
+  // render, not stored via setState-in-effect.
+  const resolvedTheme: 'light' | 'dark' = theme === 'system' ? systemPref : theme
+
+  // Sync document class + color-scheme. Pure side-effect, no setState.
   useEffect(() => {
-    const resolved = getResolvedTheme()
-    setResolvedTheme(resolved)
-
     const root = document.documentElement
-    const hasCorrectClass = root.classList.contains(resolved)
+    const hasCorrectClass = root.classList.contains(resolvedTheme)
 
     // Skip DOM class update if already correct (anti-flash: index.html IIFE set it)
     // But always sync color-scheme for native controls (buttons, inputs, scrollbars)
-    root.style.colorScheme = resolved
+    root.style.colorScheme = resolvedTheme
 
     if (hasCorrectClass) return
 
     root.classList.remove('light', 'dark')
-    root.classList.add(resolved)
-  }, [getResolvedTheme])
+    root.classList.add(resolvedTheme)
+  }, [resolvedTheme])
 
-  // Listen for system preference changes
+  // Listen for system preference changes — setState only in async callback.
   useEffect(() => {
-    if (theme !== 'system') return
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- SSR safety guard
+    if (globalThis.window === undefined) return
 
     const mediaQuery = globalThis.window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = () => {
-      const resolved = getResolvedTheme()
-      setResolvedTheme(resolved)
-
-      const root = document.documentElement
-      const hasCorrectClass = root.classList.contains(resolved)
-
-      // Always sync color-scheme for native controls
-      root.style.colorScheme = resolved
-
-      // Skip DOM class update if already correct (anti-flash)
-      if (hasCorrectClass) return
-
-      root.classList.remove('light', 'dark')
-      root.classList.add(resolved)
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemPref(event.matches ? 'dark' : 'light')
     }
 
     mediaQuery.addEventListener('change', handleChange)
     return () => {
       mediaQuery.removeEventListener('change', handleChange)
     }
-  }, [theme, getResolvedTheme])
+  }, [])
 
   const updateTheme = useCallback((newTheme: Theme) => {
     setTheme(newTheme)


### PR DESCRIPTION
## What

Closes the deferred React-Compiler rule cleanup. Re-enables `set-state-in-effect` (both `react-x` and `react-hooks` namespaces, same rule under two plugins) by refactoring the 3 real call sites so state is derived during render instead of `setState` inside an effect.

## Sites refactored

| File | Before | After |
|---|---|---|
| `useReducedMotion.ts` | `useState(false)` + `setState(matchMedia.matches)` in effect | lazy `useState(() => matchMedia…)`; effect only registers the change listener (setState in async callback) |
| `Navbar.tsx` | `useEffect(() => setMobileMenuOpen(false), [pathname])` | adjust-state-during-render: track `menuPathname`, close menu when it differs |
| `useTheme.ts` | `resolvedTheme` state set via `setState` in effect | `resolvedTheme` derived during render from `theme` + `systemPref` state; effect is pure DOM side-effect |

### useTheme detail
`resolvedTheme` is fully derivable from `theme` + system preference, so storing it as effect-driven state was redundant. Now:
- `systemPref` state, lazy-initialized from `matchMedia`, kept fresh by an always-on `prefers-color-scheme` listener (`setState` only in the async `change` callback).
- `resolvedTheme = theme === 'system' ? systemPref : theme` computed in render.
- The DOM effect (classList, `colorScheme`, anti-FOUC `hasCorrectClass` guard) is **preserved exactly** — only the `setResolvedTheme` call moved out.
- Listener is now always-on (was gated on `theme === 'system'`); keeps `systemPref` fresh so switching to `system` after a system change is correct. Behavior identical, fixes a latent staleness.

## Kept off (justified)
`react-hooks/refs` stays `off`: genuine false positive — @floating-ui's API is to pass its `setFloating` ref-setter to `ref=` (BlogList.tsx, ProjectCard.tsx), which the rule misreads as a render-time ref access.

`preserve-caught-error` line removed entirely — already fixed in source in #78.

## Verify
- lint: **0 errors / 0 warnings** (with the rule re-enabled)
- `tsc -b`: clean
- tests: **139/139** (17 files)
- Anti-FOUC theming behavior unchanged (e2e theme DOM-class assertions still pass)

## Note
React Compiler rule re-enable was explicitly scoped to this dedicated PR (correct-code refactor, not a dependency bump).